### PR TITLE
fix(watermarker): off-by-one error in watermark extraction

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+watermarker

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-watermarker
+TREND

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.22" />
+    <option name="version" value="1.9.23" />
   </component>
 </project>

--- a/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
@@ -366,7 +366,7 @@ class TextWatermarker(
             val content =
                 file.content.asSequence()
                     .drop(start)
-                    .take(end - start)
+                    .take(end - start + 1)
                     .filter { char -> char in transcoding.alphabet }
 
             if (content.count() > 0) {

--- a/watermarker/src/commonTest/kotlin/integrationTest/fileWatermarker/TextWatermarkerIntegrationTest.kt
+++ b/watermarker/src/commonTest/kotlin/integrationTest/fileWatermarker/TextWatermarkerIntegrationTest.kt
@@ -1,0 +1,76 @@
+package integrationTest.fileWatermarker
+
+import de.fraunhofer.isst.trend.watermarker.SupportedFileType
+import de.fraunhofer.isst.trend.watermarker.fileWatermarker.TextWatermark
+import de.fraunhofer.isst.trend.watermarker.fileWatermarker.TextWatermarker
+import de.fraunhofer.isst.trend.watermarker.files.TextFile
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TextWatermarkerIntegrationTest {
+    private val textWatermarker = TextWatermarker.default()
+
+    @Test
+    fun watermarkInsertionExtraction_successiveSpaces_equality() {
+        // Arrange
+        val text =
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor " +
+                "incididunt ut labore et dolore magna aliqua. Tempus imperdiet nulla malesuada " +
+                "pellentesque elit. Pellentesque id nibh tortor id aliquet lectus proin nibh nisl" +
+                ". Viverra accumsan in  nisl  nisi.  Condimentum  lacinia quis vel eros donec. " +
+                "Urna neque viverra justo"
+        val watermark = "Hello World"
+        val textFile = TextFile.fromString(text)
+        val parsedWatermark = TextWatermark.fromText(watermark)
+
+        // Add watermark
+        // Act
+        val status = textWatermarker.addWatermark(textFile, parsedWatermark)
+
+        // Assert
+        assertTrue(status.isSuccess)
+
+        // Extract Watermark
+        // Act
+        val watermarks = textWatermarker.getWatermarks(textFile)
+
+        // Assert
+        assertTrue(watermarks.isSuccess)
+        assertEquals(watermarks.value!!.size, 1)
+        val firstWatermark = watermarks.value!![0].getText().value!!
+        assertEquals(watermark, firstWatermark)
+    }
+
+    @Test
+    fun watermarkInsertionExtraction_loremIpsum_equality() {
+        // Arrange
+        val text =
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor " +
+                "incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis " +
+                "nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. " +
+                "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu " +
+                "fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in " +
+                "culpa qui officia deserunt mollit anim id est laborum."
+        val watermark = "Hello World"
+        val textFile = TextFile.fromString(text)
+        val parsedWatermark = TextWatermark.fromText(watermark)
+
+        // Add watermark
+        // Act
+        val status = textWatermarker.addWatermark(textFile, parsedWatermark)
+
+        // Assert
+        assertTrue(status.isSuccess)
+
+        // Extract Watermark
+        // Act
+        val watermarks = textWatermarker.getWatermarks(textFile)
+
+        // Assert
+        assertTrue(watermarks.isSuccess)
+        assertEquals(watermarks.value!!.size, 1)
+        val firstWatermark = watermarks.value!![0].getText().value!!
+        assertEquals(watermark, firstWatermark)
+    }
+}

--- a/watermarker/src/commonTest/kotlin/integrationTest/fileWatermarker/TextWatermarkerIntegrationTest.kt
+++ b/watermarker/src/commonTest/kotlin/integrationTest/fileWatermarker/TextWatermarkerIntegrationTest.kt
@@ -1,6 +1,11 @@
+/*
+ * Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
+ * that can be found in the LICENSE file.
+ */
 package integrationTest.fileWatermarker
 
-import de.fraunhofer.isst.trend.watermarker.SupportedFileType
 import de.fraunhofer.isst.trend.watermarker.fileWatermarker.TextWatermark
 import de.fraunhofer.isst.trend.watermarker.fileWatermarker.TextWatermarker
 import de.fraunhofer.isst.trend.watermarker.files.TextFile

--- a/watermarker/src/commonTest/kotlin/integrationTest/fileWatermarker/TextWatermarkerIntegrationTest.kt
+++ b/watermarker/src/commonTest/kotlin/integrationTest/fileWatermarker/TextWatermarkerIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ * Copyright (c) 2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
  * that can be found in the LICENSE file.


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->
 - Fixes an off-by-one error in the range used to extract the chars from a String containing a single watermark.
   - The bug only surfaces when there are multiple successive spaces; otherwise only a text char is skipped that is not part of the watermark
 - Adds test cases that ensures that extracted watermarks are equal to the inserted watermark

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #6

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
