### PR TITLE
ci: deploy watermarker docs to github pages

### DIFF
--- a/.github/workflows/watermarker_docs.yml
+++ b/.github/workflows/watermarker_docs.yml
@@ -1,18 +1,3 @@
-#
-# Copyright (c) 2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
-# (represented by Fraunhofer ISST)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software distributed under the
-# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied. See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
 name: "Watermarker: Generate API docs"
 

--- a/.github/workflows/watermarker_docs.yml
+++ b/.github/workflows/watermarker_docs.yml
@@ -47,4 +47,6 @@ jobs:
           branch: gh-pages
           folder: watermarker/build/dokka/html
           target-folder: docs
+          git-config-name: github-actions[bot]
+          git-config-email: github-actions[bot]@users.noreply.github.com
           commit-message: "docs(watermarker): updated API docs from @ ${{ github.repository }}@${{ github.sha }} 🚀"

--- a/.github/workflows/watermarker_docs.yml
+++ b/.github/workflows/watermarker_docs.yml
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+#
+# This work is licensed under the Fraunhofer License (on the basis of the MIT license)
+# that can be found in the LICENSE file.
+#
 
 name: "Watermarker: Generate API docs"
 

--- a/.github/workflows/watermarker_docs.yml
+++ b/.github/workflows/watermarker_docs.yml
@@ -1,0 +1,59 @@
+#
+# Copyright (c) 2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+# (represented by Fraunhofer ISST)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the
+# License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "Watermarker: Generate API docs"
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Generate API documentation
+        working-directory: watermarker
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+        run: ./gradlew dokkaHtml
+
+      - name: Deploy API documentation to Github Pages
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: watermarker/build/dokka/html
+          target-folder: docs
+          commit-message: "docs(watermarker): updated API docs from @ ${{ github.repository }}@${{ github.sha }} 🚀"


### PR DESCRIPTION
- Added Github workflow, that generates and deploys the KDOCs content of the watermarker library to a Github Page. 
- Note: If this is merged, please make sure that in this repo's settings, in the Pages section, the source is set to "Deploy from branch". The source branch should be set to "gh-pages" (This branch will be generated automatically the first time, the workflow runs). The source folder should be set to "docs". 
- solves #9

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
