### PR TITLE
feat: support export as a JS library

### DIFF
--- a/watermarker/build.gradle.kts
+++ b/watermarker/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
     }
     js(IR) {
         browser { }
+        binaries.library()
     }
     sourceSets {
         val commonMain by getting

--- a/watermarker/src/commonMain/kotlin/Watermarker.kt
+++ b/watermarker/src/commonMain/kotlin/Watermarker.kt
@@ -14,7 +14,10 @@ import de.fraunhofer.isst.trend.watermarker.files.TextFile
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Event
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Result
 import de.fraunhofer.isst.trend.watermarker.watermarks.Watermark
+import kotlin.js.JsExport
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 sealed class SupportedFileType {
     abstract val watermarker: FileWatermarker<*, *>
 
@@ -82,6 +85,8 @@ sealed class SupportedFileType {
     }
 }
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 open class Watermarker {
     /** Watermarks string [text] with [watermark] */
     fun textAddWatermark(

--- a/watermarker/src/commonMain/kotlin/fileWatermarker/FileWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/FileWatermarker.kt
@@ -11,7 +11,10 @@ import de.fraunhofer.isst.trend.watermarker.files.WatermarkableFile
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Result
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Status
 import de.fraunhofer.isst.trend.watermarker.watermarks.Watermark
+import kotlin.js.JsExport
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 interface FileWatermarker<File : WatermarkableFile, SpecificWatermark : Watermark> {
     /** Adds a [watermark] to [file] */
     fun addWatermark(

--- a/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
@@ -15,11 +15,14 @@ import de.fraunhofer.isst.trend.watermarker.returnTypes.Result
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Status
 import de.fraunhofer.isst.trend.watermarker.watermarks.DecodeToStringError
 import de.fraunhofer.isst.trend.watermarker.watermarks.Watermark
+import kotlin.js.JsExport
 import kotlin.math.ceil
 import kotlin.math.log
 import kotlin.math.pow
 
 /** Defines how multiple watermarks are separated */
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 sealed class SeparatorStrategy {
     /** Leaves one insertable position empty to mark the end of a watermark */
     object SkipInsertPosition : SeparatorStrategy()
@@ -31,6 +34,8 @@ sealed class SeparatorStrategy {
     class StartEndSeparatorChars(val start: Char, val end: Char) : SeparatorStrategy()
 }
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 interface Transcoding {
     val alphabet: List<Char>
 
@@ -41,6 +46,8 @@ interface Transcoding {
     fun decode(chars: Sequence<Char>): Result<List<Byte>>
 }
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 object DefaultTranscoding : Transcoding {
     override val alphabet =
         listOf(
@@ -115,6 +122,8 @@ object DefaultTranscoding : Transcoding {
     }
 }
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 class TextWatermark private constructor(
     content: List<Byte>,
     private val compression: Boolean,
@@ -220,6 +229,8 @@ class TextWatermark private constructor(
     }
 }
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 class TextWatermarker(
     private val transcoding: Transcoding,
     private val separatorStrategy: SeparatorStrategy,
@@ -440,6 +451,11 @@ class TextWatermarker(
         val separatedWatermark = getSeparatedWatermark(watermark)
         return separatedWatermark.count()
     }
+    
+    /** Counts the available number of insert positions in a [file] */
+    fun getAvailableInsertPositions(file: TextFile): Int {
+        return placement(file.content).count()
+    }
 
     /** Transforms a [watermark] into a separated watermark */
     private fun getSeparatedWatermark(watermark: Watermark): Sequence<Char> {
@@ -518,6 +534,8 @@ class TextWatermarker(
     }
 }
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 class TextWatermarkerBuilder {
     private var transcoding: Transcoding = DefaultTranscoding
     private var separatorStrategy: SeparatorStrategy =

--- a/watermarker/src/commonMain/kotlin/fileWatermarker/ZipWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/ZipWatermarker.kt
@@ -10,14 +10,19 @@ import de.fraunhofer.isst.trend.watermarker.files.ZipFile
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Result
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Status
 import de.fraunhofer.isst.trend.watermarker.watermarks.Watermark
+import kotlin.js.JsExport
 
 const val ZIP_WATERMARK_ID: UShort = 0x8777u
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 class ZipWatermark(content: List<Byte>) : Watermark(content) {
     /** Represents the Watermark by [content] as String */
     override fun toString(): String = this.content.toByteArray().contentToString()
 }
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 object ZipWatermarker : FileWatermarker<ZipFile, ZipWatermark> {
     /**
      * Adds a [watermark] to [file]

--- a/watermarker/src/commonMain/kotlin/files/TextFile.kt
+++ b/watermarker/src/commonMain/kotlin/files/TextFile.kt
@@ -8,7 +8,10 @@ package de.fraunhofer.isst.trend.watermarker.files
 
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Event
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Result
+import kotlin.js.JsExport
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 class TextFile private constructor(path: String?, var content: String) : WatermarkableFile(path) {
     /** Converts the TextFile into raw bytes */
     override fun toBytes(): List<Byte> {

--- a/watermarker/src/commonMain/kotlin/files/WatermarkableFile.kt
+++ b/watermarker/src/commonMain/kotlin/files/WatermarkableFile.kt
@@ -8,7 +8,10 @@
 package de.fraunhofer.isst.trend.watermarker.files
 
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Event
+import kotlin.js.JsExport
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 abstract class WatermarkableFile(internal val path: String?) {
     /** Converts the WatermarkableFile into raw bytes */
     abstract fun toBytes(): List<Byte>

--- a/watermarker/src/commonMain/kotlin/files/ZipFile.kt
+++ b/watermarker/src/commonMain/kotlin/files/ZipFile.kt
@@ -11,6 +11,7 @@ import de.fraunhofer.isst.trend.watermarker.helper.toBytesLittleEndian
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Event
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Result
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Status
+import kotlin.js.JsExport
 
 /**
  * | Expected zip File Format:   | Length (bytes)       | Expected Value |
@@ -38,6 +39,9 @@ import de.fraunhofer.isst.trend.watermarker.returnTypes.Status
  *
  * All numbers are expected in little endian order.
  */
+
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 class ZipFile internal constructor(
     path: String?,
     val header: ZipFileHeader,
@@ -90,6 +94,8 @@ class ZipFile internal constructor(
     }
 }
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 class ZipFileHeader internal constructor(
     internal val magicBytes: UInt,
     internal val minimumVersion: UShort,

--- a/watermarker/src/commonMain/kotlin/returnTypes/Result.kt
+++ b/watermarker/src/commonMain/kotlin/returnTypes/Result.kt
@@ -7,12 +7,17 @@
 
 package de.fraunhofer.isst.trend.watermarker.returnTypes
 
+import kotlin.js.JsExport
+import kotlin.js.JsName
+
 /**
  * This class represents the result of a function that returns a value but also can fail or produce
  * warnings.
  *
  * A Result with a Status of type Success or Warning are expected to have a value.
  */
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 class Result<T> constructor(
     val status: Status,
     val value: T? = null,
@@ -21,9 +26,11 @@ class Result<T> constructor(
     val hasValue get() = value != null
 
     /** Creates a new Result<T> from [status] and [value] */
+    @JsName("intoResult")
     fun <T> into(value: T? = null) = Result(this.status, value)
 
     /** Converts Result<T> to Status */
+    @JsName("intoStatus")
     fun into(): Status = this.status
 
     /**

--- a/watermarker/src/commonMain/kotlin/returnTypes/Status.kt
+++ b/watermarker/src/commonMain/kotlin/returnTypes/Status.kt
@@ -6,6 +6,9 @@
  */
 package de.fraunhofer.isst.trend.watermarker.returnTypes
 
+import kotlin.js.JsExport
+import kotlin.js.JsName
+
 /**
  * An Event represents different kinds of events that can occur during the execution of a function.
  * There are 3 base Variants:
@@ -16,6 +19,8 @@ package de.fraunhofer.isst.trend.watermarker.returnTypes
  * The variants Warning and Error are abstract: For each event that can occur a unique class must be
  * created that overwrites fun getMessage(): String to explain the event.
  */
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 sealed class Event(
     val source: String?,
     val severity: Int,
@@ -63,9 +68,11 @@ sealed class Event(
     abstract class Error(source: String) : Event(source, 2, ERROR)
 
     /** Creates a Status containing [this] event */
+    @JsName("intoStatus")
     fun into(): Status = Status(this)
 
     /** Creates a Result<T> with a Status containing [this] event */
+    @JsName("intoResult")
     fun <T> into(value: T? = null): Result<T> = Result(this.into(), value)
 
     companion object {
@@ -80,6 +87,8 @@ sealed class Event(
  * A Status represents the outcome of a function that can produces Errors and Warnings, holding any
  * number of events.
  */
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 class Status(event: Event? = null) {
     /**
      * Represents the severity of the Status. Used to be able to override the severity given by

--- a/watermarker/src/commonMain/kotlin/watermarks/DeflateWatermark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/DeflateWatermark.kt
@@ -9,7 +9,10 @@ package de.fraunhofer.isst.trend.watermarker.watermarks
 import de.fraunhofer.isst.trend.watermarker.helper.Compression
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Event
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Result
+import kotlin.js.JsExport
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 open class DeflateWatermark(content: List<Byte>) : Watermark(content) {
     /** Returns the inflated bytes from the Watermark */
     fun getBytes(): Result<List<Byte>> {
@@ -35,6 +38,8 @@ open class DeflateWatermark(content: List<Byte>) : Watermark(content) {
     }
 }
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 class DecodeToStringError(val reason: String) : Event.Error("DeflateWatermark.decodeToString") {
     /** Returns a String explaining the event */
     override fun getMessage(): String = "Failed to decode bytes to string: $reason."

--- a/watermarker/src/commonMain/kotlin/watermarks/Watermark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Watermark.kt
@@ -7,7 +7,10 @@
 package de.fraunhofer.isst.trend.watermarker.watermarks
 
 import de.fraunhofer.isst.trend.watermarker.helper.toHexString
+import kotlin.js.JsExport
 
+@OptIn(kotlin.js.ExperimentalJsExport::class)
+@JsExport
 open class Watermark(val content: List<Byte>) {
     /** Represents the bytes of the watermark in hex */
     override fun toString(): String = content.toHexString()


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->

Enables export of the library as a JS library. After further investigation, no better solutions than the one already described in [this comment](https://github.com/FraunhoferISST/TREND/issues/24#issuecomment-2091191097) of issue  #24 have been found. 

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #24

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
