### PR TITLE
feat(watermarker): Increase convenience for use of the StartEndSeparatorChars separator strategy

### DIFF
--- a/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
@@ -25,10 +25,15 @@ sealed class SeparatorStrategy {
     object SkipInsertPosition : SeparatorStrategy()
 
     /** Inserts [char] as separator between watermarks */
-    class SingleSeparatorChar(val char: Char) : SeparatorStrategy()
+    class SingleSeparatorChar(
+        val char: Char = DefaultTranscoding.SEPARATOR_CHAR,
+    ) : SeparatorStrategy()
 
     /** Inserts [start] before a Watermark and [end] after a Watermark as separators */
-    class StartEndSeparatorChars(val start: Char, val end: Char) : SeparatorStrategy()
+    class StartEndSeparatorChars(
+        val start: Char = DefaultTranscoding.START_SEPARATOR_CHAR,
+        val end: Char = DefaultTranscoding.END_SEPARATOR_CHAR,
+    ) : SeparatorStrategy()
 }
 
 interface Transcoding {
@@ -53,7 +58,11 @@ object DefaultTranscoding : Transcoding {
             // Medium mathematical space
             '\u205F',
         )
+
     const val SEPARATOR_CHAR = '\u2004' // Three-per-em space
+
+    const val START_SEPARATOR_CHAR = '\u2004' // Three-per-em space
+    const val END_SEPARATOR_CHAR = '\u2005' // Four-per-em space (TODO: change)
 
     private val base = alphabet.size
     private val digitsPerByte = calculateDigitsPerByte(base)
@@ -521,7 +530,7 @@ class TextWatermarker(
 class TextWatermarkerBuilder {
     private var transcoding: Transcoding = DefaultTranscoding
     private var separatorStrategy: SeparatorStrategy =
-        SeparatorStrategy.SingleSeparatorChar(DefaultTranscoding.SEPARATOR_CHAR)
+        SeparatorStrategy.SingleSeparatorChar()
     private var compression: Boolean = TextWatermark.COMPRESSION_DEFAULT
 
     /** Yields all positions where a Char of the watermark can be inserted */


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->

Added default start- and end-separators to the default transcoding and added default values to the constructors of the SeparatorStrategies. This increases the convenice of use of the library, especially when using the StartEndSeparatorChars strategy.

I chose the three-per-em space as start separator and the four-per-em space as end separator to have something to start with. At least the end separator probably still has to be changed to some other character that is better in replacing conventional white spaces.

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #45

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
