### PR TITLE
feat(watermarker): add functions for Trendmarks, TrendmarkBuilder and Textmarks to FileWatermarker

### DIFF
--- a/watermarker/src/commonMain/kotlin/fileWatermarker/FileWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/FileWatermarker.kt
@@ -10,7 +10,12 @@ package de.fraunhofer.isst.trend.watermarker.fileWatermarker
 import de.fraunhofer.isst.trend.watermarker.files.WatermarkableFile
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Result
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Status
+import de.fraunhofer.isst.trend.watermarker.watermarks.Textmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.TrendmarkBuilder
 import de.fraunhofer.isst.trend.watermarker.watermarks.Watermark
+import de.fraunhofer.isst.trend.watermarker.watermarks.toTextmarks
+import de.fraunhofer.isst.trend.watermarker.watermarks.toTrendmarks
 import kotlin.js.JsExport
 import kotlin.js.JsName
 
@@ -30,15 +35,54 @@ interface FileWatermarker<File : WatermarkableFile> {
         return addWatermark(file, watermark.watermarkContent)
     }
 
+    /** Adds a [trendmarkBuilder] to [file] */
+    @JsName("addTrendmarkBuilder")
+    fun addWatermark(
+        file: File,
+        trendmarkBuilder: TrendmarkBuilder,
+    ): Status {
+        return addWatermark(file, trendmarkBuilder.finish())
+    }
+
     /** Checks if [file] contains watermarks */
     fun containsWatermark(file: File): Boolean
 
     /** Returns all watermarks in [file] */
     fun getWatermarks(file: File): Result<List<Watermark>>
 
+    /**
+     * Returns all watermarks in [file] as Trendmarks.
+     *
+     * Returns a warning if some watermarks could not be converted to Trendmarks.
+     * Returns an error if no watermark could be converted to a Trendmark.
+     */
+    fun getTrendmarks(file: File): Result<List<Trendmark>> =
+        getWatermarks(file).toTrendmarks("${getSource()}.getTrendmarks")
+
+    /**
+     * Returns all watermarks in [file] as Textmark.
+     *
+     * When [errorOnInvalidUTF8] is true: invalid bytes sequences cause an error.
+     *                           is false: invalid bytes sequences are replace with the char �.
+     *
+     * Returns a warning if some watermarks could not be converted to Trendmarks.
+     * Returns an error if no watermark could be converted to a Trendmark.
+     *
+     * Returns a warning if some Trendmarks could not be converted to Textmarks.
+     * Returns an error if no Trendmark could be converted to a Textmark.
+     */
+    fun getTextmarks(
+        file: File,
+        errorOnInvalidUTF8: Boolean = false,
+    ): Result<List<Textmark>> =
+        getWatermarks(file).toTextmarks(errorOnInvalidUTF8, "${getSource()}.getTextmarks")
+
     /** Removes all watermarks in [file] and returns them */
     fun removeWatermarks(file: File): Result<List<Watermark>>
 
     /** Parses [bytes] as File */
     fun parseBytes(bytes: List<Byte>): Result<File>
+
+    /** Returns the name of the FileWatermark. Used in Event messages. */
+    fun getSource(): String
 }

--- a/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
@@ -365,6 +365,8 @@ class TextWatermarker(
         fun default(): TextWatermarker = TextWatermarkerBuilder().build().value!!
     }
 
+    override fun getSource(): String = SOURCE
+
     class IncompleteWatermarkWarning : Event.Warning("$SOURCE.getWatermark") {
         /** Returns a String explaining the event */
         override fun getMessage() = "Could not restore a complete watermark!"

--- a/watermarker/src/commonMain/kotlin/fileWatermarker/ZipWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/ZipWatermarker.kt
@@ -16,6 +16,11 @@ const val ZIP_WATERMARK_ID: UShort = 0x8777u
 
 @JsExport
 object ZipWatermarker : FileWatermarker<ZipFile> {
+    const val SOURCE = "ZipWatermarker"
+
+    /** Returns the name of the FileWatermark. Used in Event messages. */
+    override fun getSource(): String = SOURCE
+
     /**
      * Adds a [watermark] to [file]
      * Returns an error if the size of the ExtraFields exceed UShort::MAX

--- a/watermarker/src/commonTest/kotlin/unitTest/WatermarkerTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/WatermarkerTest.kt
@@ -8,13 +8,13 @@ package unitTest
 
 import de.fraunhofer.isst.trend.watermarker.SupportedFileType
 import de.fraunhofer.isst.trend.watermarker.Watermarker
-import de.fraunhofer.isst.trend.watermarker.Watermarker.FailedTextmarkExtractionsWarning
-import de.fraunhofer.isst.trend.watermarker.Watermarker.FailedTrendmarkExtractionsWarning
 import de.fraunhofer.isst.trend.watermarker.fileWatermarker.DefaultTranscoding
 import de.fraunhofer.isst.trend.watermarker.fileWatermarker.TextWatermarker
 import de.fraunhofer.isst.trend.watermarker.watermarks.SizedWatermark
 import de.fraunhofer.isst.trend.watermarker.watermarks.Textmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.Textmark.FailedTextmarkExtractionsWarning
 import de.fraunhofer.isst.trend.watermarker.watermarks.Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.Trendmark.FailedTrendmarkExtractionsWarning
 import de.fraunhofer.isst.trend.watermarker.watermarks.Watermark
 import platform
 import kotlin.test.Test
@@ -385,7 +385,7 @@ class WatermarkerTest {
         val unknownTagError = Trendmark.UnknownTagError(0x54u)
         val expectedStatus = unknownTagError.into()
         expectedStatus.addEvent(unknownTagError)
-        expectedStatus.addEvent(FailedTrendmarkExtractionsWarning("Watermarker.textGetTrendmarks"))
+        expectedStatus.addEvent(FailedTrendmarkExtractionsWarning("Watermarker.textGetTextmarks"))
         val expectedTextmarks = listOf(Textmark.sized(watermarkString))
 
         // Act


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->
Adds functions to add `Trendmark` and `TrendmarkBuilder` (e.g., `Textmark`) as Watermark to the `FileWatermarker` interface and impls. them.
Adds functions to extract watermarks as `Trendmark` and `Textmark` to the `FileWatermarker` interace and impls. them.

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #59 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
