### PR TITLE
feat(watermarker): add support for TrendmarkBuilder to getMinimumInsertPositions

### DIFF
--- a/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
@@ -12,6 +12,7 @@ import de.fraunhofer.isst.trend.watermarker.helper.toUnicodeRepresentation
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Event
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Result
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Status
+import de.fraunhofer.isst.trend.watermarker.watermarks.TrendmarkBuilder
 import de.fraunhofer.isst.trend.watermarker.watermarks.Watermark
 import kotlin.js.JsExport
 import kotlin.js.JsName
@@ -330,6 +331,14 @@ class TextWatermarker(
     /** Counts the minimum number of insert positions needed in a text to insert the [watermark] */
     fun getMinimumInsertPositions(watermark: Watermark): Int =
         getMinimumInsertPositions(watermark.watermarkContent)
+
+    /**
+     * Counts the minimum number of insert positions needed in a text to insert the
+     * [trendmarkBuilder]
+     */
+    @JsName("getMimimumInsertPositionsTrendmarkBuilder")
+    fun getMinimumInsertPositions(trendmarkBuilder: TrendmarkBuilder): Int =
+        getMinimumInsertPositions(trendmarkBuilder.finish())
 
     /** Transforms a [watermark] into a separated watermark */
     private fun getSeparatedWatermark(watermark: List<Byte>): Sequence<Char> {


### PR DESCRIPTION

## Description
<!-- Describe and give details about the changes. -->
Implements support for `TrendmarkBuilder` into `TextWatermarker.getMinimumInsertPositions`.

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #74 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
