### PR TITLE
refactor(watermarker): rename all variants of `Trendmark` from `*Watermark` to `*Trendmark`

### DIFF
--- a/docs/docs/Trendmark.md
+++ b/docs/docs/Trendmark.md
@@ -23,19 +23,19 @@ watermarks that change the content itself (e.g. compression).
 
 | Tag (in hex) | Class name | Meaning |
 | -- | -- | -- |
-| 00 | RawWatermark | raw bytes without special encoding |
-| 01 | SizedWatermark | size + raw bytes |
-| 02 | CRC32Watermark | CRC32 checksum + raw bytes |
-| 03 | SizedCRC32Watermark | size + CRC32 checksum + raw bytes |
-| 04 | SHA3256Watermark | SHA3-256 hash + raw bytes |
-| 05 | SizedSHA3256Watermark | size + SHA3-256 hash + raw bytes |
+| 00 | RawTrendmark | raw bytes without special encoding |
+| 01 | SizedTrendmark | size + raw bytes |
+| 02 | CRC32Trendmark | CRC32 checksum + raw bytes |
+| 03 | SizedCRC32Trendmark | size + CRC32 checksum + raw bytes |
+| 04 | SHA3256Trendmark | SHA3-256 hash + raw bytes |
+| 05 | SizedSHA3256Trendmark | size + SHA3-256 hash + raw bytes |
 | -- | -- | -- |
-| fe | CompressedRawWatermark | compressed bytes |
-| fd | CompressedSizedWatermark | size + compressed bytes |
-| fc | CompressedCRC32Watermark | CRC32 checksum + compressed bytes |
-| fb | CompressedSizedCRC32Watermark | size + CRC32 checksum + compressed bytes |
-| fa | CompressedSHA3256Watermark | SHA3-256 hash + compressed bytes |
-| f9 | CompressedSizedSHA3256Watermark | size + SHA3-256 hash + compressed bytes |
+| fe | CompressedRawTrendmark | compressed bytes |
+| fd | CompressedSizedTrendmark | size + compressed bytes |
+| fc | CompressedCRC32Trendmark | CRC32 checksum + compressed bytes |
+| fb | CompressedSizedCRC32Trendmark | size + CRC32 checksum + compressed bytes |
+| fa | CompressedSHA3256Trendmark | SHA3-256 hash + compressed bytes |
+| f9 | CompressedSizedSHA3256Trendmark | size + SHA3-256 hash + compressed bytes |
 | -- | -- | -- |
 | ff | Custom | Reserved for custom Trendmark implementations |
 
@@ -49,20 +49,20 @@ Compressing the example watermark content results in the bytes (f3 c9 2f 4a cd 5
 Only the content is compressed, potentially allowing to use the additional information to increase 
 the watermark robustness.
 
-### RawWatermark
+### RawTrendmark
 
 | tag | raw bytes |
 | -- | -- |
 | 00 | 4c 6f 72 65 6d 20 69 70 73 75 6d |
 
-### SizedWatermark
+### SizedTrendmark
 The size is calculated over the entire watermark.
 
 | tag | size in 32 bits little-endian | raw bytes |
 | -- | -- | -- |
 | 01 | 10 00 00 00 | 4c 6f 72 65 6d 20 69 70 73 75 6d |
 
-### CRC32Watermark
+### CRC32Trendmark
 The [CRC32](https://en.wikipedia.org/wiki/Cyclic_redundancy_check) checksum is calculated over the
 entire watermark, replacing the bytes containing the checksum with null bytes.
 
@@ -70,7 +70,7 @@ entire watermark, replacing the bytes containing the checksum with null bytes.
 | -- | -- | -- |
 | 02 | 87 0b 16 35 | 4c 6f 72 65 6d 20 49 70 73 75 6d |
 
-### SizedCRC32Watermark
+### SizedCRC32Trendmark
 The size and CRC32 checksum are calculated over the entire watermark, replacing the bytes containing
 the checksum with null bytes.
 
@@ -78,7 +78,7 @@ the checksum with null bytes.
 | -- | -- | -- | -- |
 | 03 | 14 00 00 00 | 1e 85 5b 04 | 4c 6f 72 65 6d 20 49 70 73 75 6d |
 
-### SHA3256Watermark
+### SHA3256Trendmark
 The [SHA3-256](https://en.wikipedia.org/wiki/SHA-3) hash is calculated over the entire watermark,
 replacing the bytes containing the hash with null bytes.
 
@@ -86,7 +86,7 @@ replacing the bytes containing the hash with null bytes.
 | -- | -- | -- |
 | 04 | de 02 65 dd 6b 16 a0 b4 ab 05 a4 39 36 c0 73 12 4f 66 a2 aa 55 b3 9c 2b 30 b6 19 de 1c 11 c9 50 | 4c 6f 72 65 6d 20 49 70 73 75 6d |
 
-### SizedSHA3256Watermark
+### SizedSHA3256Trendmark
 The size and SHA3-256 hash are calculated over the entire watermark, replacing the bytes containing the
 hash are replaced with zero-bytes.
 
@@ -94,14 +94,14 @@ hash are replaced with zero-bytes.
 | -- | -- | -- | -- |
 | 05 | 30 00 00 00 | f2 17 a5 ae 43 c5 70 a2 33 2b b5 90 60 23 45 da 6d 35 d3 34 95 5c 17 83 ec ec 2e 49 66 45 c9 1a | 4c 6f 72 65 6d 20 49 70 73 75 6d |
 
-### CompressedRawWatermark
+### CompressedRawTrendmark
 Trendmark uses DEFLATE as compression algorithm (see RFC 1951).
 
 | tag | compressed content |
 | -- | -- |
 | fe | f3 c9 2f 4a cd 55 f0 2c 28 2e cd 05 00 |
 
-### CompressedSizedWatermark
+### CompressedSizedTrendmark
 The size is calculated over the entire watermark.
 Only the content is compressed, potentially allowing to use the additional information to increase 
 the watermark robustness.
@@ -112,7 +112,7 @@ Trendmark uses [DEFLATE](https://en.wikipedia.org/wiki/Deflate) as compression a
 | -- | -- | -- |
 | fd | 12 00 00 00 | f3 c9 2f 4a cd 55 f0 2c 28 2e cd 05 00 |
 
-### CompressedCRC32Watermark
+### CompressedCRC32Trendmark
 The CRC32 checksum is calculated over the entire watermark, replacing the bytes containing the
 checksum with null bytes.
 Only the content is compressed, potentially allowing to use the additional information to increase 
@@ -123,7 +123,7 @@ Trendmark uses DEFLATE as compression algorithm (see RFC 1951).
 | -- | -- | -- |
 | fc | 9d 54 46 ff | f3 c9 2f 4a cd 55 f0 2c 28 2e cd 05 00 |
 
-### CompressedSizedCRC32Watermark
+### CompressedSizedCRC32Trendmark
 The size and CRC32 checksum are calculated over the entire watermark, replacing the bytes containing
 the checksum with null bytes.
 Only the content is compressed, potentially allowing to use the additional information to increase 
@@ -134,7 +134,7 @@ Trendmark uses DEFLATE as compression algorithm (see RFC 1951).
 | -- | -- | -- | -- |
 | fb | 16 00 00 00 | 13 07 a7 d2 | f3 c9 2f 4a cd 55 f0 2c 28 2e cd 05 00 |
 
-### CompressedSHA3256Watermark
+### CompressedSHA3256Trendmark
 The SHA3-256 hash is calculated over the entire watermark, replacing the bytes containing the hash
 with null bytes.
 Only the content is compressed, potentially allowing to use the additional information to increase 
@@ -145,7 +145,7 @@ Trendmark uses DEFLATE as compression algorithm (see RFC 1951).
 | -- | -- | -- |
 | fa | df 60 19 45 c2 77 98 5d 0e 59 cc f8 9b 27 ed 9f 9c 98 85 a5 b3 3e c7 47 fa 88 68 74 a8 ef 77 5b | f3 c9 2f 4a cd 55 f0 2c 28 2e cd 05 00 |
 
-### CompressedSizedSHA3256Watermark
+### CompressedSizedSHA3256Trendmark
 The size and SHA3-256 hash are calculated over the entire watermark, replacing the bytes containing the
 hash are replaced with zero-bytes.
 Only the content is compressed, potentially allowing to use the additional information to increase 

--- a/watermarker/src/commonMain/kotlin/watermarks/TextWatermark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/TextWatermark.kt
@@ -85,20 +85,20 @@ class TextWatermark private constructor(
 
             val textWatermark =
                 when (trendmark) {
-                    is RawWatermark -> TextWatermark(text)
-                    is SizedWatermark -> TextWatermark(text, sized = true)
-                    is CompressedRawWatermark -> TextWatermark(text, compressed = true)
-                    is CompressedSizedWatermark ->
+                    is RawTrendmark -> TextWatermark(text)
+                    is SizedTrendmark -> TextWatermark(text, sized = true)
+                    is CompressedRawTrendmark -> TextWatermark(text, compressed = true)
+                    is CompressedSizedTrendmark ->
                         TextWatermark(text, compressed = true, sized = true)
 
-                    is CRC32Watermark,
-                    is SizedCRC32Watermark,
-                    is CompressedCRC32Watermark,
-                    is CompressedSizedCRC32Watermark,
-                    is SHA3256Watermark,
-                    is SizedSHA3256Watermark,
-                    is CompressedSHA3256Watermark,
-                    is CompressedSizedSHA3256Watermark,
+                    is CRC32Trendmark,
+                    is SizedCRC32Trendmark,
+                    is CompressedCRC32Trendmark,
+                    is CompressedSizedCRC32Trendmark,
+                    is SHA3256Trendmark,
+                    is SizedSHA3256Trendmark,
+                    is CompressedSHA3256Trendmark,
+                    is CompressedSizedSHA3256Trendmark,
                     -> {
                         status.addEvent(UnsupportedTrendmarkError(trendmark.getSource()))
                         return status.into<_>()
@@ -136,13 +136,13 @@ class TextWatermark private constructor(
         val content = text.encodeToByteArray().asList()
 
         return if (sized && compressed) {
-            CompressedSizedWatermark.new(content)
+            CompressedSizedTrendmark.new(content)
         } else if (sized) {
-            SizedWatermark.new(content)
+            SizedTrendmark.new(content)
         } else if (compressed) {
-            CompressedRawWatermark.new(content)
+            CompressedRawTrendmark.new(content)
         } else {
-            RawWatermark.new(content)
+            RawTrendmark.new(content)
         }
     }
 

--- a/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
@@ -117,19 +117,19 @@ sealed class Trendmark(
 
             val watermark =
                 when (val tag = extractTag(input)) {
-                    RawWatermark.TYPE_TAG -> RawWatermark(input)
-                    SizedWatermark.TYPE_TAG -> SizedWatermark(input)
-                    CRC32Watermark.TYPE_TAG -> CRC32Watermark(input)
-                    SizedCRC32Watermark.TYPE_TAG -> SizedCRC32Watermark(input)
-                    SHA3256Watermark.TYPE_TAG -> SHA3256Watermark(input)
-                    SizedSHA3256Watermark.TYPE_TAG -> SizedSHA3256Watermark(input)
-                    CompressedRawWatermark.TYPE_TAG -> CompressedRawWatermark(input)
-                    CompressedSizedWatermark.TYPE_TAG -> CompressedSizedWatermark(input)
-                    CompressedCRC32Watermark.TYPE_TAG -> CompressedCRC32Watermark(input)
-                    CompressedSizedCRC32Watermark.TYPE_TAG -> CompressedSizedCRC32Watermark(input)
-                    CompressedSHA3256Watermark.TYPE_TAG -> CompressedSHA3256Watermark(input)
-                    CompressedSizedSHA3256Watermark.TYPE_TAG ->
-                        CompressedSizedSHA3256Watermark(input)
+                    RawTrendmark.TYPE_TAG -> RawTrendmark(input)
+                    SizedTrendmark.TYPE_TAG -> SizedTrendmark(input)
+                    CRC32Trendmark.TYPE_TAG -> CRC32Trendmark(input)
+                    SizedCRC32Trendmark.TYPE_TAG -> SizedCRC32Trendmark(input)
+                    SHA3256Trendmark.TYPE_TAG -> SHA3256Trendmark(input)
+                    SizedSHA3256Trendmark.TYPE_TAG -> SizedSHA3256Trendmark(input)
+                    CompressedRawTrendmark.TYPE_TAG -> CompressedRawTrendmark(input)
+                    CompressedSizedTrendmark.TYPE_TAG -> CompressedSizedTrendmark(input)
+                    CompressedCRC32Trendmark.TYPE_TAG -> CompressedCRC32Trendmark(input)
+                    CompressedSizedCRC32Trendmark.TYPE_TAG -> CompressedSizedCRC32Trendmark(input)
+                    CompressedSHA3256Trendmark.TYPE_TAG -> CompressedSHA3256Trendmark(input)
+                    CompressedSizedSHA3256Trendmark.TYPE_TAG ->
+                        CompressedSizedSHA3256Trendmark(input)
                     else -> return UnknownTagError(tag).into<_>()
                 }
             val status = watermark.validate()
@@ -176,18 +176,18 @@ sealed class Trendmark(
     override fun equals(other: Any?): Boolean {
         val equalClass =
             when (this) {
-                is RawWatermark -> other is RawWatermark
-                is SizedWatermark -> other is SizedWatermark
-                is CRC32Watermark -> other is CRC32Watermark
-                is SizedCRC32Watermark -> other is SizedCRC32Watermark
-                is SHA3256Watermark -> other is SHA3256Watermark
-                is SizedSHA3256Watermark -> other is SizedSHA3256Watermark
-                is CompressedRawWatermark -> other is CompressedRawWatermark
-                is CompressedSizedWatermark -> other is CompressedSizedWatermark
-                is CompressedCRC32Watermark -> other is CompressedCRC32Watermark
-                is CompressedSizedCRC32Watermark -> other is CompressedSizedCRC32Watermark
-                is CompressedSHA3256Watermark -> other is CompressedSHA3256Watermark
-                is CompressedSizedSHA3256Watermark -> other is CompressedSizedSHA3256Watermark
+                is RawTrendmark -> other is RawTrendmark
+                is SizedTrendmark -> other is SizedTrendmark
+                is CRC32Trendmark -> other is CRC32Trendmark
+                is SizedCRC32Trendmark -> other is SizedCRC32Trendmark
+                is SHA3256Trendmark -> other is SHA3256Trendmark
+                is SizedSHA3256Trendmark -> other is SizedSHA3256Trendmark
+                is CompressedRawTrendmark -> other is CompressedRawTrendmark
+                is CompressedSizedTrendmark -> other is CompressedSizedTrendmark
+                is CompressedCRC32Trendmark -> other is CompressedCRC32Trendmark
+                is CompressedSizedCRC32Trendmark -> other is CompressedSizedCRC32Trendmark
+                is CompressedSHA3256Trendmark -> other is CompressedSHA3256Trendmark
+                is CompressedSizedSHA3256Trendmark -> other is CompressedSizedSHA3256Trendmark
             }
         if (!equalClass) return false
 
@@ -600,15 +600,15 @@ fun Result<List<Watermark>>.toTrendmarks(source: String = "Trendmark"): Result<L
 }
 
 @JsExport
-class RawWatermark(content: List<Byte>) : Trendmark(content) {
+class RawTrendmark(content: List<Byte>) : Trendmark(content) {
     companion object {
-        const val SOURCE = "Trendmark.RawWatermark"
+        const val SOURCE = "Trendmark.RawTrendmark"
         const val TYPE_TAG: UByte = 0u
 
-        /** Creates a new `RawWatermark` with containing [content] */
-        fun new(content: List<Byte>): RawWatermark = RawWatermark(createRaw(TYPE_TAG, content))
+        /** Creates a new `RawTrendmark` with containing [content] */
+        fun new(content: List<Byte>): RawTrendmark = RawTrendmark(createRaw(TYPE_TAG, content))
 
-        /** Creates a new `RawWatermark` with [text] as content */
+        /** Creates a new `RawTrendmark` with [text] as content */
         fun fromString(text: String) = new(text.encodeToByteArray().asList())
 
         internal fun createRaw(
@@ -628,9 +628,9 @@ class RawWatermark(content: List<Byte>) : Trendmark(content) {
 }
 
 @JsExport
-class SizedWatermark(content: List<Byte>) : Trendmark(content), Trendmark.Sized {
+class SizedTrendmark(content: List<Byte>) : Trendmark(content), Trendmark.Sized {
     companion object {
-        const val SOURCE = "Trendmark.SizedWatermark"
+        const val SOURCE = "Trendmark.SizedTrendmark"
         const val TYPE_TAG: UByte = 1u
 
         /**
@@ -642,12 +642,12 @@ class SizedWatermark(content: List<Byte>) : Trendmark(content), Trendmark.Sized 
         const val SIZE_START_INDEX = TAG_SIZE
         const val SIZE_END_INDEX = SIZE_START_INDEX + SIZE_SIZE - 1
 
-        /** Creates a new `SizedWatermark` containing [content] */
-        fun new(content: List<Byte>): SizedWatermark {
-            return SizedWatermark(createRaw(TYPE_TAG, content))
+        /** Creates a new `SizedTrendmark` containing [content] */
+        fun new(content: List<Byte>): SizedTrendmark {
+            return SizedTrendmark(createRaw(TYPE_TAG, content))
         }
 
-        /** Creates a new `SizedWatermark` with [text] as content */
+        /** Creates a new `SizedTrendmark` with [text] as content */
         fun fromString(text: String) = new(text.encodeToByteArray().asList())
 
         internal fun createRaw(
@@ -680,22 +680,22 @@ class SizedWatermark(content: List<Byte>) : Trendmark(content), Trendmark.Sized 
 }
 
 @JsExport
-class CRC32Watermark(content: List<Byte>) : Trendmark(content), Trendmark.Checksum {
+class CRC32Trendmark(content: List<Byte>) : Trendmark(content), Trendmark.Checksum {
     companion object {
-        const val SOURCE = "Trendmark.CRC32Watermark"
+        const val SOURCE = "Trendmark.CRC32Trendmark"
         const val TYPE_TAG: UByte = 2u
         const val CHECKSUM_SIZE = 4
         const val CHECKSUM_START_INDEX = TAG_SIZE
         const val CHECKSUM_END_INDEX = CHECKSUM_START_INDEX + CHECKSUM_SIZE - 1
 
-        /** Creates a new `CRC32Watermark` containing [content] */
-        fun new(content: List<Byte>): CRC32Watermark {
-            val watermark = CRC32Watermark(createRaw(TYPE_TAG, content))
+        /** Creates a new `CRC32Trendmark` containing [content] */
+        fun new(content: List<Byte>): CRC32Trendmark {
+            val watermark = CRC32Trendmark(createRaw(TYPE_TAG, content))
             watermark.updateChecksum()
             return watermark
         }
 
-        /** Creates a new `CRC32Watermark` with [text] as content */
+        /** Creates a new `CRC32Trendmark` with [text] as content */
         fun fromString(text: String) = new(text.encodeToByteArray().asList())
 
         internal fun createRaw(
@@ -748,10 +748,10 @@ class CRC32Watermark(content: List<Byte>) : Trendmark(content), Trendmark.Checks
 }
 
 @JsExport
-class SizedCRC32Watermark(content: List<Byte>) :
+class SizedCRC32Trendmark(content: List<Byte>) :
     Trendmark(content), Trendmark.Sized, Trendmark.Checksum {
     companion object {
-        const val SOURCE = "Trendmark.SizedCRC32Watermark"
+        const val SOURCE = "Trendmark.SizedCRC32Trendmark"
         const val TYPE_TAG: UByte = 3u
         const val SIZE_SIZE: Int = 4
         const val SIZE_START_INDEX = TAG_SIZE
@@ -760,14 +760,14 @@ class SizedCRC32Watermark(content: List<Byte>) :
         const val CHECKSUM_START_INDEX = SIZE_END_INDEX + 1
         const val CHECKSUM_END_INDEX = CHECKSUM_START_INDEX + CHECKSUM_SIZE - 1
 
-        /** Creates a new `SizedCRC32Watermark` containing [content] */
-        fun new(content: List<Byte>): SizedCRC32Watermark {
-            val watermark = SizedCRC32Watermark(createRaw(TYPE_TAG, content))
+        /** Creates a new `SizedCRC32Trendmark` containing [content] */
+        fun new(content: List<Byte>): SizedCRC32Trendmark {
+            val watermark = SizedCRC32Trendmark(createRaw(TYPE_TAG, content))
             watermark.updateChecksum()
             return watermark
         }
 
-        /** Creates a new `SizedCRC32Watermark` with [text] as content */
+        /** Creates a new `SizedCRC32Trendmark` with [text] as content */
         fun fromString(text: String) = new(text.encodeToByteArray().asList())
 
         internal fun createRaw(
@@ -818,27 +818,27 @@ class SizedCRC32Watermark(content: List<Byte>) :
                 value!!
             }
 
-        return Result.success(CRC32Watermark.calculateChecksum(checksumContent))
+        return Result.success(CRC32Trendmark.calculateChecksum(checksumContent))
     }
 }
 
 @JsExport
-class SHA3256Watermark(content: List<Byte>) : Trendmark(content), Trendmark.Hash {
+class SHA3256Trendmark(content: List<Byte>) : Trendmark(content), Trendmark.Hash {
     companion object {
-        const val SOURCE = "Trendmark.SHA3256Watermark"
+        const val SOURCE = "Trendmark.SHA3256Trendmark"
         const val TYPE_TAG: UByte = 4u
         const val HASH_SIZE = 32
         const val HASH_START_INDEX = TAG_SIZE
         const val HASH_END_INDEX = HASH_START_INDEX + HASH_SIZE - 1
 
-        /** Creates a new `SHA3256Watermark` containing [content] */
-        fun new(content: List<Byte>): SHA3256Watermark {
-            val watermark = SHA3256Watermark(createRaw(TYPE_TAG, content))
+        /** Creates a new `SHA3256Trendmark` containing [content] */
+        fun new(content: List<Byte>): SHA3256Trendmark {
+            val watermark = SHA3256Trendmark(createRaw(TYPE_TAG, content))
             watermark.updateHash()
             return watermark
         }
 
-        /** Creates a new `SHA3256Watermark` with [text] as content */
+        /** Creates a new `SHA3256Trendmark` with [text] as content */
         fun fromString(text: String) = new(text.encodeToByteArray().asList())
 
         internal fun createRaw(
@@ -894,10 +894,10 @@ class SHA3256Watermark(content: List<Byte>) : Trendmark(content), Trendmark.Hash
 }
 
 @JsExport
-class SizedSHA3256Watermark(content: List<Byte>) :
+class SizedSHA3256Trendmark(content: List<Byte>) :
     Trendmark(content), Trendmark.Sized, Trendmark.Hash {
     companion object {
-        const val SOURCE = "Trendmark.SizedSHA3256Watermark"
+        const val SOURCE = "Trendmark.SizedSHA3256Trendmark"
         const val TYPE_TAG: UByte = 5u
         const val SIZE_SIZE = 4
         const val SIZE_START_INDEX = TAG_SIZE
@@ -906,14 +906,14 @@ class SizedSHA3256Watermark(content: List<Byte>) :
         const val HASH_START_INDEX = SIZE_END_INDEX + 1
         const val HASH_END_INDEX = HASH_START_INDEX + HASH_SIZE - 1
 
-        /** Creates a new `SizedSHA3256Watermark` containing [content] */
-        fun new(content: List<Byte>): SizedSHA3256Watermark {
-            val watermark = SizedSHA3256Watermark(createRaw(TYPE_TAG, content))
+        /** Creates a new `SizedSHA3256Trendmark` containing [content] */
+        fun new(content: List<Byte>): SizedSHA3256Trendmark {
+            val watermark = SizedSHA3256Trendmark(createRaw(TYPE_TAG, content))
             watermark.updateHash()
             return watermark
         }
 
-        /** Creates a new `SizedSHA3256Watermark` with [text] as content */
+        /** Creates a new `SizedSHA3256Trendmark` with [text] as content */
         fun fromString(text: String) = new(text.encodeToByteArray().asList())
 
         internal fun createRaw(
@@ -966,23 +966,23 @@ class SizedSHA3256Watermark(content: List<Byte>) :
                 value!!
             }
 
-        return Result.success(SHA3256Watermark.calculateHash(hashInput))
+        return Result.success(SHA3256Trendmark.calculateHash(hashInput))
     }
 }
 
 @JsExport
-class CompressedRawWatermark(content: List<Byte>) : Trendmark(content), Trendmark.Compressed {
+class CompressedRawTrendmark(content: List<Byte>) : Trendmark(content), Trendmark.Compressed {
     companion object {
-        const val SOURCE = "Trendmark.CompressedRawWatermark"
+        const val SOURCE = "Trendmark.CompressedRawTrendmark"
         const val TYPE_TAG: UByte = 254u
 
-        /** Creates a new `CompressedRawWatermark` containing [content] */
-        fun new(content: List<Byte>): CompressedRawWatermark {
+        /** Creates a new `CompressedRawTrendmark` containing [content] */
+        fun new(content: List<Byte>): CompressedRawTrendmark {
             val compressedContent = Compression.deflate(content)
-            return CompressedRawWatermark(RawWatermark.createRaw(TYPE_TAG, compressedContent))
+            return CompressedRawTrendmark(RawTrendmark.createRaw(TYPE_TAG, compressedContent))
         }
 
-        /** Creates a new `CompressedRawWatermark` with [text] as content */
+        /** Creates a new `CompressedRawTrendmark` with [text] as content */
         fun fromString(text: String) = new(text.encodeToByteArray().asList())
     }
 
@@ -1000,19 +1000,19 @@ class CompressedRawWatermark(content: List<Byte>) : Trendmark(content), Trendmar
 }
 
 @JsExport
-class CompressedSizedWatermark(content: List<Byte>) :
+class CompressedSizedTrendmark(content: List<Byte>) :
     Trendmark(content), Trendmark.Sized, Trendmark.Compressed {
     companion object {
-        const val SOURCE = "Trendmark.CompressedSizedWatermark"
+        const val SOURCE = "Trendmark.CompressedSizedTrendmark"
         const val TYPE_TAG: UByte = 253u
 
-        /** Creates a new `CompressedSizedWatermark` containing [content] */
-        fun new(content: List<Byte>): CompressedSizedWatermark {
+        /** Creates a new `CompressedSizedTrendmark` containing [content] */
+        fun new(content: List<Byte>): CompressedSizedTrendmark {
             val compressedContent = Compression.deflate(content)
-            return CompressedSizedWatermark(SizedWatermark.createRaw(TYPE_TAG, compressedContent))
+            return CompressedSizedTrendmark(SizedTrendmark.createRaw(TYPE_TAG, compressedContent))
         }
 
-        /** Creates a new `CompressedSizedWatermark` with [text] as content */
+        /** Creates a new `CompressedSizedTrendmark` with [text] as content */
         fun fromString(text: String) = new(text.encodeToByteArray().asList())
     }
 
@@ -1024,32 +1024,32 @@ class CompressedSizedWatermark(content: List<Byte>) :
 
     /** Returns the decoded information stored in the Trendmark */
     override fun getContent(): Result<List<Byte>> {
-        val compressedContent = watermarkContent.drop(TAG_SIZE + SizedWatermark.SIZE_SIZE)
+        val compressedContent = watermarkContent.drop(TAG_SIZE + SizedTrendmark.SIZE_SIZE)
         return Compression.inflate(compressedContent)
     }
 
     /** Returns the range of bytes (inclusive) within the watermark bytes that represent the size */
     override fun getSizeRange(): IntRange =
-        SizedWatermark.SIZE_START_INDEX..SizedWatermark.SIZE_END_INDEX
+        SizedTrendmark.SIZE_START_INDEX..SizedTrendmark.SIZE_END_INDEX
 }
 
 @JsExport
-class CompressedCRC32Watermark(content: List<Byte>) :
+class CompressedCRC32Trendmark(content: List<Byte>) :
     Trendmark(content), Trendmark.Compressed, Trendmark.Checksum {
     companion object {
-        const val SOURCE = "Trendmark.CompressedCRC32Watermark"
+        const val SOURCE = "Trendmark.CompressedCRC32Trendmark"
         const val TYPE_TAG: UByte = 252u
 
-        /** Creates a new `CompressedCRC32Watermark` containing [content] */
-        fun new(content: List<Byte>): CompressedCRC32Watermark {
+        /** Creates a new `CompressedCRC32Trendmark` containing [content] */
+        fun new(content: List<Byte>): CompressedCRC32Trendmark {
             val compressedContent = Compression.deflate(content)
             val watermark =
-                CompressedCRC32Watermark(CRC32Watermark.createRaw(TYPE_TAG, compressedContent))
+                CompressedCRC32Trendmark(CRC32Trendmark.createRaw(TYPE_TAG, compressedContent))
             watermark.updateChecksum()
             return watermark
         }
 
-        /** Creates a new `CompressedCRC32Watermark` with [text] as content */
+        /** Creates a new `CompressedCRC32Trendmark` with [text] as content */
         fun fromString(text: String) = new(text.encodeToByteArray().asList())
     }
 
@@ -1063,11 +1063,11 @@ class CompressedCRC32Watermark(content: List<Byte>) :
      * Returns the range of bytes (inclusive) within the watermark bytes that represent the checksum
      */
     override fun getChecksumRange(): IntRange =
-        CRC32Watermark.CHECKSUM_START_INDEX..CRC32Watermark.CHECKSUM_END_INDEX
+        CRC32Trendmark.CHECKSUM_START_INDEX..CRC32Trendmark.CHECKSUM_END_INDEX
 
     /** Returns the decoded information stored in the Trendmark */
     override fun getContent(): Result<List<Byte>> {
-        val compressedContent = watermarkContent.drop(TAG_SIZE + CRC32Watermark.CHECKSUM_SIZE)
+        val compressedContent = watermarkContent.drop(TAG_SIZE + CRC32Trendmark.CHECKSUM_SIZE)
         return Compression.inflate(compressedContent)
     }
 
@@ -1081,29 +1081,29 @@ class CompressedCRC32Watermark(content: List<Byte>) :
                 value!!
             }
 
-        return Result.success(CRC32Watermark.calculateChecksum(checksumContent))
+        return Result.success(CRC32Trendmark.calculateChecksum(checksumContent))
     }
 }
 
 @JsExport
-class CompressedSizedCRC32Watermark(content: List<Byte>) :
+class CompressedSizedCRC32Trendmark(content: List<Byte>) :
     Trendmark(content), Trendmark.Sized, Trendmark.Checksum {
     companion object {
-        const val SOURCE = "Trendmark.CompressedSizedCRC32Watermark"
+        const val SOURCE = "Trendmark.CompressedSizedCRC32Trendmark"
         const val TYPE_TAG: UByte = 251u
 
-        /** Creates a new `CompressedSizedCRC32Watermark` containing [content] */
-        fun new(content: List<Byte>): CompressedSizedCRC32Watermark {
+        /** Creates a new `CompressedSizedCRC32Trendmark` containing [content] */
+        fun new(content: List<Byte>): CompressedSizedCRC32Trendmark {
             val compressedContent = Compression.deflate(content)
             val watermark =
-                CompressedSizedCRC32Watermark(
-                    SizedCRC32Watermark.createRaw(TYPE_TAG, compressedContent),
+                CompressedSizedCRC32Trendmark(
+                    SizedCRC32Trendmark.createRaw(TYPE_TAG, compressedContent),
                 )
             watermark.updateChecksum()
             return watermark
         }
 
-        /** Creates a new `CompressedSizedCRC32Watermark` with [text] as content */
+        /** Creates a new `CompressedSizedCRC32Trendmark` with [text] as content */
         fun fromString(text: String) = new(text.encodeToByteArray().asList())
     }
 
@@ -1115,18 +1115,18 @@ class CompressedSizedCRC32Watermark(content: List<Byte>) :
 
     /** Returns the range of bytes (inclusive) within the watermark bytes that represent the size */
     override fun getSizeRange(): IntRange =
-        SizedCRC32Watermark.SIZE_START_INDEX..SizedCRC32Watermark.SIZE_END_INDEX
+        SizedCRC32Trendmark.SIZE_START_INDEX..SizedCRC32Trendmark.SIZE_END_INDEX
 
     /**
      * Returns the range of bytes (inclusive) within the watermark bytes that represent the checksum
      */
     override fun getChecksumRange(): IntRange =
-        SizedCRC32Watermark.CHECKSUM_START_INDEX..SizedCRC32Watermark.CHECKSUM_END_INDEX
+        SizedCRC32Trendmark.CHECKSUM_START_INDEX..SizedCRC32Trendmark.CHECKSUM_END_INDEX
 
     /** Returns the decoded information stored in the Trendmark */
     override fun getContent(): Result<List<Byte>> {
         val contentOffset =
-            TAG_SIZE + SizedCRC32Watermark.SIZE_SIZE + SizedCRC32Watermark.CHECKSUM_SIZE
+            TAG_SIZE + SizedCRC32Trendmark.SIZE_SIZE + SizedCRC32Trendmark.CHECKSUM_SIZE
         val compressedContent = watermarkContent.drop(contentOffset)
         return Compression.inflate(compressedContent)
     }
@@ -1143,29 +1143,29 @@ class CompressedSizedCRC32Watermark(content: List<Byte>) :
                 value!!
             }
 
-        return Result.success(CRC32Watermark.calculateChecksum(checksumContent))
+        return Result.success(CRC32Trendmark.calculateChecksum(checksumContent))
     }
 }
 
 @JsExport
-class CompressedSHA3256Watermark(content: List<Byte>) :
+class CompressedSHA3256Trendmark(content: List<Byte>) :
     Trendmark(content), Trendmark.Compressed, Trendmark.Hash {
     companion object {
-        const val SOURCE = "Trendmark.CompressedSHA3256Watermark"
+        const val SOURCE = "Trendmark.CompressedSHA3256Trendmark"
         const val TYPE_TAG: UByte = 250u
 
-        /** Creates a new `CompressedSHA3256Watermark` containing [content] */
-        fun new(content: List<Byte>): CompressedSHA3256Watermark {
+        /** Creates a new `CompressedSHA3256Trendmark` containing [content] */
+        fun new(content: List<Byte>): CompressedSHA3256Trendmark {
             val compressedContent = Compression.deflate(content)
             val watermark =
-                CompressedSHA3256Watermark(
-                    SHA3256Watermark.createRaw(TYPE_TAG, compressedContent),
+                CompressedSHA3256Trendmark(
+                    SHA3256Trendmark.createRaw(TYPE_TAG, compressedContent),
                 )
             watermark.updateHash()
             return watermark
         }
 
-        /** Creates a new `CompressedSHA3256Watermark` with [text] as content */
+        /** Creates a new `CompressedSHA3256Trendmark` with [text] as content */
         fun fromString(text: String) = new(text.encodeToByteArray().asList())
     }
 
@@ -1177,7 +1177,7 @@ class CompressedSHA3256Watermark(content: List<Byte>) :
 
     /** Returns the range of bytes (inclusive) within the watermark bytes that represent the hash */
     override fun getHashRange(): IntRange =
-        SHA3256Watermark.HASH_START_INDEX..SHA3256Watermark.HASH_END_INDEX
+        SHA3256Trendmark.HASH_START_INDEX..SHA3256Trendmark.HASH_END_INDEX
 
     /**
      * Calculates the SHA3-256 hash of the watermark content.
@@ -1191,36 +1191,36 @@ class CompressedSHA3256Watermark(content: List<Byte>) :
                 if (!isSuccess) return status.into<_>()
                 value!!
             }
-        return Result.success(SHA3256Watermark.calculateHash(hashInput))
+        return Result.success(SHA3256Trendmark.calculateHash(hashInput))
     }
 
     /** Returns the decoded information stored in the Trendmark */
     override fun getContent(): Result<List<Byte>> {
-        val contentOffset = TAG_SIZE + SHA3256Watermark.HASH_SIZE
+        val contentOffset = TAG_SIZE + SHA3256Trendmark.HASH_SIZE
         val compressedContent = watermarkContent.drop(contentOffset)
         return Compression.inflate(compressedContent)
     }
 }
 
 @JsExport
-class CompressedSizedSHA3256Watermark(content: List<Byte>) :
+class CompressedSizedSHA3256Trendmark(content: List<Byte>) :
     Trendmark(content), Trendmark.Compressed, Trendmark.Sized, Trendmark.Hash {
     companion object {
-        const val SOURCE = "Trendmark.CompressedSizedSHA3256Watermark"
+        const val SOURCE = "Trendmark.CompressedSizedSHA3256Trendmark"
         const val TYPE_TAG: UByte = 249u
 
-        /** Creates a new `CompressedSizedSHA3256Watermark` containing [content] */
-        fun new(content: List<Byte>): CompressedSizedSHA3256Watermark {
+        /** Creates a new `CompressedSizedSHA3256Trendmark` containing [content] */
+        fun new(content: List<Byte>): CompressedSizedSHA3256Trendmark {
             val compressedContent = Compression.deflate(content)
             val watermark =
-                CompressedSizedSHA3256Watermark(
-                    SizedSHA3256Watermark.createRaw(TYPE_TAG, compressedContent),
+                CompressedSizedSHA3256Trendmark(
+                    SizedSHA3256Trendmark.createRaw(TYPE_TAG, compressedContent),
                 )
             watermark.updateHash()
             return watermark
         }
 
-        /** Creates a new `CompressedSizedSHA3256Watermark` with [text] as content */
+        /** Creates a new `CompressedSizedSHA3256Trendmark` with [text] as content */
         fun fromString(text: String) = new(text.encodeToByteArray().asList())
     }
 
@@ -1232,11 +1232,11 @@ class CompressedSizedSHA3256Watermark(content: List<Byte>) :
 
     /** Returns the range of bytes (inclusive) within the watermark bytes that represent the size */
     override fun getSizeRange(): IntRange =
-        SizedSHA3256Watermark.SIZE_START_INDEX..SizedSHA3256Watermark.SIZE_END_INDEX
+        SizedSHA3256Trendmark.SIZE_START_INDEX..SizedSHA3256Trendmark.SIZE_END_INDEX
 
     /** Returns the range of bytes (inclusive) within the watermark bytes that represent the hash */
     override fun getHashRange(): IntRange =
-        SizedSHA3256Watermark.HASH_START_INDEX..SizedSHA3256Watermark.HASH_END_INDEX
+        SizedSHA3256Trendmark.HASH_START_INDEX..SizedSHA3256Trendmark.HASH_END_INDEX
 
     /**
      * Calculates the SHA3-256 hash of the watermark content.
@@ -1250,13 +1250,13 @@ class CompressedSizedSHA3256Watermark(content: List<Byte>) :
                 if (!isSuccess) return status.into<_>()
                 value!!
             }
-        return Result.success(SHA3256Watermark.calculateHash(hashInput))
+        return Result.success(SHA3256Trendmark.calculateHash(hashInput))
     }
 
     /** Returns the decoded information stored in the Trendmark */
     override fun getContent(): Result<List<Byte>> {
         val contentOffset =
-            TAG_SIZE + SizedSHA3256Watermark.SIZE_SIZE + SizedSHA3256Watermark.HASH_SIZE
+            TAG_SIZE + SizedSHA3256Trendmark.SIZE_SIZE + SizedSHA3256Trendmark.HASH_SIZE
         val compressedContent = watermarkContent.drop(contentOffset)
         return Compression.inflate(compressedContent)
     }

--- a/watermarker/src/commonTest/kotlin/unitTest/WatermarkerTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/WatermarkerTest.kt
@@ -10,7 +10,7 @@ import de.fraunhofer.isst.trend.watermarker.SupportedFileType
 import de.fraunhofer.isst.trend.watermarker.Watermarker
 import de.fraunhofer.isst.trend.watermarker.fileWatermarker.DefaultTranscoding
 import de.fraunhofer.isst.trend.watermarker.fileWatermarker.TextWatermarker
-import de.fraunhofer.isst.trend.watermarker.watermarks.SizedWatermark
+import de.fraunhofer.isst.trend.watermarker.watermarks.SizedTrendmark
 import de.fraunhofer.isst.trend.watermarker.watermarks.TextWatermark
 import de.fraunhofer.isst.trend.watermarker.watermarks.TextWatermark.FailedTextWatermarkExtractionsWarning
 import de.fraunhofer.isst.trend.watermarker.watermarks.Trendmark
@@ -309,7 +309,7 @@ class WatermarkerTest {
     @Test
     fun textGetTrendmarks_trendmarkedString_success() {
         // Arrange
-        val expectedTrendmarks = listOf(SizedWatermark.fromString(watermarkString))
+        val expectedTrendmarks = listOf(SizedTrendmark.fromString(watermarkString))
 
         // Act
         val trendmarks = watermarker.textGetTrendmarks(textWithTrendmarks)
@@ -340,7 +340,7 @@ class WatermarkerTest {
         val expectedStatus = unkownTagError.into()
         expectedStatus.addEvent(unkownTagError)
         expectedStatus.addEvent(FailedTrendmarkExtractionsWarning("Watermarker.textGetTrendmarks"))
-        val expectedTrendmarks = listOf(SizedWatermark.fromString(watermarkString))
+        val expectedTrendmarks = listOf(SizedTrendmark.fromString(watermarkString))
 
         // Act
         val trendmarks = watermarker.textGetTrendmarks(textWithWatermarksAndTrendmarks)

--- a/watermarker/src/commonTest/kotlin/unitTest/watermarks/TextWatermarkTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/watermarks/TextWatermarkTest.kt
@@ -6,18 +6,18 @@
  */
 package unitTest.watermarks
 
-import de.fraunhofer.isst.trend.watermarker.watermarks.CRC32Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedCRC32Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedRawWatermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSHA3256Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSizedCRC32Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSizedSHA3256Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSizedWatermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.RawWatermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.SHA3256Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.SizedCRC32Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.SizedSHA3256Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.SizedWatermark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CRC32Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedCRC32Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedRawTrendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSHA3256Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSizedCRC32Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSizedSHA3256Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSizedTrendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.RawTrendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.SHA3256Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.SizedCRC32Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.SizedSHA3256Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.SizedTrendmark
 import de.fraunhofer.isst.trend.watermarker.watermarks.TextWatermark
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -33,7 +33,7 @@ class TextWatermarkTest {
     @Test
     fun new_loremIpsum_success() {
         // Arrange
-        val expectedTrendmark = RawWatermark.new(textBytes)
+        val expectedTrendmark = RawTrendmark.new(textBytes)
 
         // Act
         val textWatermark = TextWatermark.new(text)
@@ -52,7 +52,7 @@ class TextWatermarkTest {
     @Test
     fun compressed_loremIpsum_success() {
         // Arrange
-        val expectedTrendmark = CompressedRawWatermark.new(textBytes)
+        val expectedTrendmark = CompressedRawTrendmark.new(textBytes)
 
         // Act
         val textWatermark = TextWatermark.compressed(text)
@@ -71,7 +71,7 @@ class TextWatermarkTest {
     @Test
     fun sized_loremIpsum_success() {
         // Arrange
-        val expectedTrendmark = SizedWatermark.new(textBytes)
+        val expectedTrendmark = SizedTrendmark.new(textBytes)
 
         // Act
         val textWatermark = TextWatermark.sized(text)
@@ -90,7 +90,7 @@ class TextWatermarkTest {
     @Test
     fun compressedAndSized_loremIpsum_success() {
         // Arrange
-        val expectedTrendmark = CompressedSizedWatermark.new(textBytes)
+        val expectedTrendmark = CompressedSizedTrendmark.new(textBytes)
 
         // Act
         val textWatermark = TextWatermark.compressedAndSized(text)
@@ -107,9 +107,9 @@ class TextWatermarkTest {
     }
 
     @Test
-    fun fromTrendmark_RawWatermark_success() {
+    fun fromTrendmark_RawTrendmark_success() {
         // Arrange
-        val initialTrendmark = RawWatermark.new(textBytes)
+        val initialTrendmark = RawTrendmark.new(textBytes)
 
         // Act
         val textWatermarkResult = TextWatermark.fromTrendmark(initialTrendmark)
@@ -126,9 +126,9 @@ class TextWatermarkTest {
     }
 
     @Test
-    fun fromTrendmark_SizedWatermark_success() {
+    fun fromTrendmark_SizedTrendmark_success() {
         // Arrange
-        val initialTrendmark = SizedWatermark.new(textBytes)
+        val initialTrendmark = SizedTrendmark.new(textBytes)
 
         // Act
         val textWatermarkResult = TextWatermark.fromTrendmark(initialTrendmark)
@@ -145,9 +145,9 @@ class TextWatermarkTest {
     }
 
     @Test
-    fun fromTrendmark_CompressedSizedWatermark_success() {
+    fun fromTrendmark_CompressedSizedTrendmark_success() {
         // Arrange
-        val initialTrendmark = CompressedSizedWatermark.new(textBytes)
+        val initialTrendmark = CompressedSizedTrendmark.new(textBytes)
 
         // Act
         val textWatermarkResult = TextWatermark.fromTrendmark(initialTrendmark)
@@ -164,10 +164,10 @@ class TextWatermarkTest {
     }
 
     @Test
-    fun fromTrendmark_CRC32Watermark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_CRC32Trendmark_UnsupportedTrendmarkError() {
         // Arrange
-        val trendmark = CRC32Watermark.new(textBytes)
-        val expectedStatus = TextWatermark.UnsupportedTrendmarkError(CRC32Watermark.SOURCE).into()
+        val trendmark = CRC32Trendmark.new(textBytes)
+        val expectedStatus = TextWatermark.UnsupportedTrendmarkError(CRC32Trendmark.SOURCE).into()
 
         // Act
         val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
@@ -179,11 +179,11 @@ class TextWatermarkTest {
     }
 
     @Test
-    fun fromTrendmark_SizedCRC32Watermark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_SizedCRC32Trendmark_UnsupportedTrendmarkError() {
         // Arrange
-        val trendmark = SizedCRC32Watermark.new(textBytes)
+        val trendmark = SizedCRC32Trendmark.new(textBytes)
         val expectedStatus =
-            TextWatermark.UnsupportedTrendmarkError(SizedCRC32Watermark.SOURCE).into()
+            TextWatermark.UnsupportedTrendmarkError(SizedCRC32Trendmark.SOURCE).into()
 
         // Act
         val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
@@ -195,11 +195,11 @@ class TextWatermarkTest {
     }
 
     @Test
-    fun fromTrendmark_CompressedCRC32Watermark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_CompressedCRC32Trendmark_UnsupportedTrendmarkError() {
         // Arrange
-        val trendmark = CompressedCRC32Watermark.new(textBytes)
+        val trendmark = CompressedCRC32Trendmark.new(textBytes)
         val expectedStatus =
-            TextWatermark.UnsupportedTrendmarkError(CompressedCRC32Watermark.SOURCE).into()
+            TextWatermark.UnsupportedTrendmarkError(CompressedCRC32Trendmark.SOURCE).into()
 
         // Act
         val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
@@ -211,11 +211,11 @@ class TextWatermarkTest {
     }
 
     @Test
-    fun fromTrendmark_CompressedSizedCRC32Watermark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_CompressedSizedCRC32Trendmark_UnsupportedTrendmarkError() {
         // Arrange
-        val trendmark = CompressedSizedCRC32Watermark.new(textBytes)
+        val trendmark = CompressedSizedCRC32Trendmark.new(textBytes)
         val expectedStatus =
-            TextWatermark.UnsupportedTrendmarkError(CompressedSizedCRC32Watermark.SOURCE).into()
+            TextWatermark.UnsupportedTrendmarkError(CompressedSizedCRC32Trendmark.SOURCE).into()
 
         // Act
         val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
@@ -227,10 +227,10 @@ class TextWatermarkTest {
     }
 
     @Test
-    fun fromTrendmark_SHA3256Watermark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_SHA3256Trendmark_UnsupportedTrendmarkError() {
         // Arrange
-        val trendmark = SHA3256Watermark.new(textBytes)
-        val expectedStatus = TextWatermark.UnsupportedTrendmarkError(SHA3256Watermark.SOURCE).into()
+        val trendmark = SHA3256Trendmark.new(textBytes)
+        val expectedStatus = TextWatermark.UnsupportedTrendmarkError(SHA3256Trendmark.SOURCE).into()
 
         // Act
         val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
@@ -242,11 +242,11 @@ class TextWatermarkTest {
     }
 
     @Test
-    fun fromTrendmark_SizedSHA3256Watermark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_SizedSHA3256Trendmark_UnsupportedTrendmarkError() {
         // Arrange
-        val trendmark = SizedSHA3256Watermark.new(textBytes)
+        val trendmark = SizedSHA3256Trendmark.new(textBytes)
         val expectedStatus =
-            TextWatermark.UnsupportedTrendmarkError(SizedSHA3256Watermark.SOURCE).into()
+            TextWatermark.UnsupportedTrendmarkError(SizedSHA3256Trendmark.SOURCE).into()
 
         // Act
         val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
@@ -258,11 +258,11 @@ class TextWatermarkTest {
     }
 
     @Test
-    fun fromTrendmark_CompressedSHA3256Watermark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_CompressedSHA3256Trendmark_UnsupportedTrendmarkError() {
         // Arrange
-        val trendmark = CompressedSHA3256Watermark.new(textBytes)
+        val trendmark = CompressedSHA3256Trendmark.new(textBytes)
         val expectedStatus =
-            TextWatermark.UnsupportedTrendmarkError(CompressedSHA3256Watermark.SOURCE).into()
+            TextWatermark.UnsupportedTrendmarkError(CompressedSHA3256Trendmark.SOURCE).into()
 
         // Act
         val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
@@ -274,11 +274,11 @@ class TextWatermarkTest {
     }
 
     @Test
-    fun fromTrendmark_CompressedSizedSHA3256Watermark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_CompressedSizedSHA3256Trendmark_UnsupportedTrendmarkError() {
         // Arrange
-        val trendmark = CompressedSizedSHA3256Watermark.new(textBytes)
+        val trendmark = CompressedSizedSHA3256Trendmark.new(textBytes)
         val expectedStatus =
-            TextWatermark.UnsupportedTrendmarkError(CompressedSizedSHA3256Watermark.SOURCE).into()
+            TextWatermark.UnsupportedTrendmarkError(CompressedSizedSHA3256Trendmark.SOURCE).into()
 
         // Act
         val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)

--- a/watermarker/src/commonTest/kotlin/unitTest/watermarks/TrendmarkTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/watermarks/TrendmarkTest.kt
@@ -8,18 +8,18 @@ package unitTest.watermarks
 
 import de.fraunhofer.isst.trend.watermarker.helper.toBytesLittleEndian
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Status
-import de.fraunhofer.isst.trend.watermarker.watermarks.CRC32Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedCRC32Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedRawWatermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSHA3256Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSizedCRC32Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSizedSHA3256Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSizedWatermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.RawWatermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.SHA3256Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.SizedCRC32Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.SizedSHA3256Watermark
-import de.fraunhofer.isst.trend.watermarker.watermarks.SizedWatermark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CRC32Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedCRC32Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedRawTrendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSHA3256Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSizedCRC32Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSizedSHA3256Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.CompressedSizedTrendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.RawTrendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.SHA3256Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.SizedCRC32Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.SizedSHA3256Trendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.SizedTrendmark
 import de.fraunhofer.isst.trend.watermarker.watermarks.Trendmark
 import de.fraunhofer.isst.trend.watermarker.watermarks.TrendmarkInterface
 import kotlin.test.Test
@@ -33,12 +33,12 @@ class TrendmarkTest {
         listOf<Byte>(-13, -55, 47, 74, -51, 85, -16, 44, 40, 46, -51, 5, 0)
 
     @Test
-    fun rawWatermark_creation_success() {
+    fun rawTrendmark_creation_success() {
         // Arrange
-        val expected = listOf(RawWatermark.TYPE_TAG.toByte()) + content
+        val expected = listOf(RawTrendmark.TYPE_TAG.toByte()) + content
 
         // Act
-        val watermark = RawWatermark.new(content)
+        val watermark = RawTrendmark.new(content)
         val extractedContent = watermark.getContent()
 
         // Assert
@@ -49,18 +49,18 @@ class TrendmarkTest {
     }
 
     @Test
-    fun rawWatermark_invalidTag_error() {
+    fun rawTrendmark_invalidTag_error() {
         // Arrange
         val watermarkContent = listOf((-1).toByte()) + content
         val expectedStatus =
             Trendmark.InvalidTagError(
-                "Trendmark.RawWatermark",
+                "Trendmark.RawTrendmark",
                 0u,
                 255u,
             ).into().toString()
 
         // Act
-        val watermark = RawWatermark(watermarkContent)
+        val watermark = RawTrendmark(watermarkContent)
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
 
@@ -75,12 +75,12 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedRawWatermark_creation_success() {
+    fun compressedRawTrendmark_creation_success() {
         // Arrange
-        val expected = listOf(CompressedRawWatermark.TYPE_TAG.toByte()) + compressedContent
+        val expected = listOf(CompressedRawTrendmark.TYPE_TAG.toByte()) + compressedContent
 
         // Act
-        val watermark = CompressedRawWatermark.new(content)
+        val watermark = CompressedRawTrendmark.new(content)
         val extractedContent = watermark.getContent()
 
         // Assert
@@ -91,18 +91,18 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedRawWatermark_invalidTag_error() {
+    fun compressedRawTrendmark_invalidTag_error() {
         // Arrange
         val watermarkContent = listOf((-1).toByte()) + compressedContent
         val expectedStatus =
             Trendmark.InvalidTagError(
-                "Trendmark.CompressedRawWatermark",
+                "Trendmark.CompressedRawTrendmark",
                 254u,
                 255u,
             ).into().toString()
 
         // Act
-        val watermark = CompressedRawWatermark(watermarkContent)
+        val watermark = CompressedRawTrendmark(watermarkContent)
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
 
@@ -117,17 +117,17 @@ class TrendmarkTest {
     }
 
     @Test
-    fun sizedWatermark_creation_success() {
+    fun sizedTrendmark_creation_success() {
         // Arrange
         val expectedSize =
-            (TrendmarkInterface.TAG_SIZE + SizedWatermark.SIZE_SIZE + content.size).toUInt()
+            (TrendmarkInterface.TAG_SIZE + SizedTrendmark.SIZE_SIZE + content.size).toUInt()
         val expected =
-            listOf(SizedWatermark.TYPE_TAG.toByte()) +
+            listOf(SizedTrendmark.TYPE_TAG.toByte()) +
                 expectedSize.toBytesLittleEndian() +
                 content
 
         // Act
-        val watermark = SizedWatermark.new(content)
+        val watermark = SizedTrendmark.new(content)
         val extractedContent = watermark.getContent()
         val extractedSize = watermark.extractSize()
 
@@ -141,23 +141,23 @@ class TrendmarkTest {
     }
 
     @Test
-    fun sizedWatermark_invalidTag_error() {
+    fun sizedTrendmark_invalidTag_error() {
         // Arrange
         val expectedSize =
-            (TrendmarkInterface.TAG_SIZE + SizedWatermark.SIZE_SIZE + content.size).toUInt()
+            (TrendmarkInterface.TAG_SIZE + SizedTrendmark.SIZE_SIZE + content.size).toUInt()
         val watermarkContent =
             listOf((-1).toByte()) +
                 expectedSize.toBytesLittleEndian() +
                 content
         val expectedStatus =
             Trendmark.InvalidTagError(
-                "Trendmark.SizedWatermark",
+                "Trendmark.SizedTrendmark",
                 1u,
                 255u,
             ).into().toString()
 
         // Act
-        val watermark = SizedWatermark(watermarkContent)
+        val watermark = SizedTrendmark(watermarkContent)
         val extractedSize = watermark.extractSize()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -173,23 +173,23 @@ class TrendmarkTest {
     }
 
     @Test
-    fun sizedWatermark_mismatchedSize_warning() {
+    fun sizedTrendmark_mismatchedSize_warning() {
         // Arrange
         val invalidSize =
-            (TrendmarkInterface.TAG_SIZE + SizedWatermark.SIZE_SIZE + content.size + 1).toUInt()
+            (TrendmarkInterface.TAG_SIZE + SizedTrendmark.SIZE_SIZE + content.size + 1).toUInt()
         val watermarkContent =
-            listOf(SizedWatermark.TYPE_TAG.toByte()) +
+            listOf(SizedTrendmark.TYPE_TAG.toByte()) +
                 invalidSize.toBytesLittleEndian() +
                 content
         val expectedStatus =
             Trendmark.MismatchedSizeWarning(
-                "Trendmark.SizedWatermark",
+                "Trendmark.SizedTrendmark",
                 invalidSize.toInt(),
                 invalidSize.toInt() - 1,
             ).into().toString()
 
         // Act
-        val watermark = SizedWatermark(watermarkContent)
+        val watermark = SizedTrendmark(watermarkContent)
         val extractedSize = watermark.extractSize()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -205,21 +205,21 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedSizedWatermark_creation_success() {
+    fun compressedSizedTrendmark_creation_success() {
         // Arrange
         val expectedSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedWatermark.SIZE_SIZE +
+                    SizedTrendmark.SIZE_SIZE +
                     compressedContent.size
             ).toUInt()
         val expected =
-            listOf(CompressedSizedWatermark.TYPE_TAG.toByte()) +
+            listOf(CompressedSizedTrendmark.TYPE_TAG.toByte()) +
                 expectedSize.toBytesLittleEndian() +
                 compressedContent
 
         // Act
-        val watermark = CompressedSizedWatermark.new(content)
+        val watermark = CompressedSizedTrendmark.new(content)
         val extractedContent = watermark.getContent()
         val extractedSize = watermark.extractSize()
 
@@ -233,12 +233,12 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedSizedWatermark_invalidTag_error() {
+    fun compressedSizedTrendmark_invalidTag_error() {
         // Arrange
         val expectedSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedWatermark.SIZE_SIZE +
+                    SizedTrendmark.SIZE_SIZE +
                     compressedContent.size
             ).toUInt()
         val watermarkContent =
@@ -247,13 +247,13 @@ class TrendmarkTest {
                 compressedContent
         val expectedStatus =
             Trendmark.InvalidTagError(
-                "Trendmark.CompressedSizedWatermark",
+                "Trendmark.CompressedSizedTrendmark",
                 253u,
                 255u,
             ).into().toString()
 
         // Act
-        val watermark = CompressedSizedWatermark(watermarkContent)
+        val watermark = CompressedSizedTrendmark(watermarkContent)
         val extractedSize = watermark.extractSize()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -269,28 +269,28 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedSizedWatermark_mismatchedSize_warning() {
+    fun compressedSizedTrendmark_mismatchedSize_warning() {
         // Arrange
         val invalidSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedWatermark.SIZE_SIZE +
+                    SizedTrendmark.SIZE_SIZE +
                     compressedContent.size +
                     1
             ).toUInt()
         val watermarkContent =
-            listOf(CompressedSizedWatermark.TYPE_TAG.toByte()) +
+            listOf(CompressedSizedTrendmark.TYPE_TAG.toByte()) +
                 invalidSize.toBytesLittleEndian() +
                 compressedContent
         val expectedStatus =
             Trendmark.MismatchedSizeWarning(
-                "Trendmark.CompressedSizedWatermark",
+                "Trendmark.CompressedSizedTrendmark",
                 invalidSize.toInt(),
                 invalidSize.toInt() - 1,
             ).into().toString()
 
         // Act
-        val watermark = CompressedSizedWatermark(watermarkContent)
+        val watermark = CompressedSizedTrendmark(watermarkContent)
         val extractedSize = watermark.extractSize()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -306,14 +306,14 @@ class TrendmarkTest {
     }
 
     @Test
-    fun crc32Watermark_creation_success() {
+    fun crc32Trendmark_creation_success() {
         // Arrange
         val expectedCrc32 = 0x35160B87u
         val expected =
-            listOf(CRC32Watermark.TYPE_TAG.toByte()) + expectedCrc32.toBytesLittleEndian() + content
+            listOf(CRC32Trendmark.TYPE_TAG.toByte()) + expectedCrc32.toBytesLittleEndian() + content
 
         // Act
-        val watermark = CRC32Watermark.new(content)
+        val watermark = CRC32Trendmark.new(content)
         val extractedChecksum = watermark.extractChecksum()
         val extractedContent = watermark.getContent()
 
@@ -327,20 +327,20 @@ class TrendmarkTest {
     }
 
     @Test
-    fun crc32Watermark_invalidTag_error() {
+    fun crc32Trendmark_invalidTag_error() {
         // Arrange
         val expectedCrc32 = 0xBFC71733u
         val watermarkContent =
             listOf((-1).toByte()) + expectedCrc32.toBytesLittleEndian() + content
         val expectedStatus =
             Trendmark.InvalidTagError(
-                "Trendmark.CRC32Watermark",
+                "Trendmark.CRC32Trendmark",
                 2u,
                 255u,
             ).into().toString()
 
         // Act
-        val watermark = CRC32Watermark(watermarkContent)
+        val watermark = CRC32Trendmark(watermarkContent)
         val extractedChecksum = watermark.extractChecksum()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -356,23 +356,23 @@ class TrendmarkTest {
     }
 
     @Test
-    fun crc32Watermark_invalidChecksum_warning() {
+    fun crc32Trendmark_invalidChecksum_warning() {
         // Arrange
         val expectedCrc32 = 0x35160B87u
         val invalidCrc32 = 0xFFFFFFFFu
         val watermarkContent =
-            listOf(CRC32Watermark.TYPE_TAG.toByte()) +
+            listOf(CRC32Trendmark.TYPE_TAG.toByte()) +
                 invalidCrc32.toBytesLittleEndian() +
                 content
         val expectedStatus =
             Trendmark.InvalidChecksumWarning(
-                "Trendmark.CRC32Watermark",
+                "Trendmark.CRC32Trendmark",
                 invalidCrc32,
                 expectedCrc32,
             ).into()
 
         // Act
-        val watermark = CRC32Watermark(watermarkContent)
+        val watermark = CRC32Trendmark(watermarkContent)
         val extractedChecksum = watermark.extractChecksum()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -388,16 +388,16 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedCRC32Watermark_creation_success() {
+    fun compressedCRC32Trendmark_creation_success() {
         // Arrange
         val expectedCrc32 = 0xFF46549Du
         val expected =
-            listOf(CompressedCRC32Watermark.TYPE_TAG.toByte()) +
+            listOf(CompressedCRC32Trendmark.TYPE_TAG.toByte()) +
                 expectedCrc32.toBytesLittleEndian() +
                 compressedContent
 
         // Act
-        val watermark = CompressedCRC32Watermark.new(content)
+        val watermark = CompressedCRC32Trendmark.new(content)
         val extractedChecksum = watermark.extractChecksum()
         val extractedContent = watermark.getContent()
 
@@ -411,20 +411,20 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedCRC32Watermark_invalidTag_error() {
+    fun compressedCRC32Trendmark_invalidTag_error() {
         // Arrange
         val expectedCrc32 = 0x15C089FFu
         val watermarkContent =
             listOf((-1).toByte()) + expectedCrc32.toBytesLittleEndian() + compressedContent
         val expectedStatus =
             Trendmark.InvalidTagError(
-                "Trendmark.CompressedCRC32Watermark",
+                "Trendmark.CompressedCRC32Trendmark",
                 252u,
                 255u,
             ).into().toString()
 
         // Act
-        val watermark = CompressedCRC32Watermark(watermarkContent)
+        val watermark = CompressedCRC32Trendmark(watermarkContent)
         val extractedChecksum = watermark.extractChecksum()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -440,23 +440,23 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedCRC32Watermark_invalidChecksum_warning() {
+    fun compressedCRC32Trendmark_invalidChecksum_warning() {
         // Arrange
         val expectedCrc32 = 0xFF46549Du
         val invalidCrc32 = 0xFFFFFFFFu
         val watermarkContent =
-            listOf(CompressedCRC32Watermark.TYPE_TAG.toByte()) +
+            listOf(CompressedCRC32Trendmark.TYPE_TAG.toByte()) +
                 invalidCrc32.toBytesLittleEndian() +
                 compressedContent
         val expectedStatus =
             Trendmark.InvalidChecksumWarning(
-                "Trendmark.CompressedCRC32Watermark",
+                "Trendmark.CompressedCRC32Trendmark",
                 invalidCrc32,
                 expectedCrc32,
             ).into()
 
         // Act
-        val watermark = CompressedCRC32Watermark(watermarkContent)
+        val watermark = CompressedCRC32Trendmark(watermarkContent)
         val extractedChecksum = watermark.extractChecksum()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -472,24 +472,24 @@ class TrendmarkTest {
     }
 
     @Test
-    fun sizedCRC32Watermark_creation_success() {
+    fun sizedCRC32Trendmark_creation_success() {
         // Arrange
         val expectedSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedCRC32Watermark.SIZE_SIZE +
-                    SizedCRC32Watermark.CHECKSUM_SIZE +
+                    SizedCRC32Trendmark.SIZE_SIZE +
+                    SizedCRC32Trendmark.CHECKSUM_SIZE +
                     content.size
             ).toUInt()
         val expectedCrc32 = 0x045B851Eu
         val expected =
-            listOf(SizedCRC32Watermark.TYPE_TAG.toByte()) +
+            listOf(SizedCRC32Trendmark.TYPE_TAG.toByte()) +
                 expectedSize.toBytesLittleEndian() +
                 expectedCrc32.toBytesLittleEndian() +
                 content
 
         // Act
-        val watermark = SizedCRC32Watermark.new(content)
+        val watermark = SizedCRC32Trendmark.new(content)
         val extractedChecksum = watermark.extractChecksum()
         val extractedContent = watermark.getContent()
         val extractedSize = watermark.extractSize()
@@ -506,14 +506,14 @@ class TrendmarkTest {
     }
 
     @Test
-    fun sizedCRC32Watermark_invalidTag_error() {
+    fun sizedCRC32Trendmark_invalidTag_error() {
         // Arrange
         val expectedCrc32 = 0x735EA3E1u
         val size =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedCRC32Watermark.SIZE_SIZE +
-                    SizedCRC32Watermark.CHECKSUM_SIZE +
+                    SizedCRC32Trendmark.SIZE_SIZE +
+                    SizedCRC32Trendmark.CHECKSUM_SIZE +
                     content.size
             ).toUInt()
         val watermarkContent =
@@ -523,13 +523,13 @@ class TrendmarkTest {
                 content
         val expectedStatus =
             Trendmark.InvalidTagError(
-                "Trendmark.SizedCRC32Watermark",
+                "Trendmark.SizedCRC32Trendmark",
                 3u,
                 255u,
             ).into().toString()
 
         // Act
-        val watermark = SizedCRC32Watermark(watermarkContent)
+        val watermark = SizedCRC32Trendmark(watermarkContent)
         val extractedChecksum = watermark.extractChecksum()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -545,41 +545,41 @@ class TrendmarkTest {
     }
 
     @Test
-    fun sizedCRC32Watermark_mismatchedSizeInvalidChecksum_warning() {
+    fun sizedCRC32Trendmark_mismatchedSizeInvalidChecksum_warning() {
         // Arrange
         val expectedCrc32 = 0xD3B90546u
         val invalidCrc32 = 0xFFFFFFFFu
         val invalidSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedCRC32Watermark.SIZE_SIZE +
-                    SizedCRC32Watermark.CHECKSUM_SIZE +
+                    SizedCRC32Trendmark.SIZE_SIZE +
+                    SizedCRC32Trendmark.CHECKSUM_SIZE +
                     content.size +
                     1
             ).toUInt()
         val watermarkContent =
-            listOf(SizedCRC32Watermark.TYPE_TAG.toByte()) +
+            listOf(SizedCRC32Trendmark.TYPE_TAG.toByte()) +
                 invalidSize.toBytesLittleEndian() +
                 invalidCrc32.toBytesLittleEndian() +
                 content
         val expectedStatus = Status.success()
         expectedStatus.addEvent(
             Trendmark.MismatchedSizeWarning(
-                "Trendmark.SizedCRC32Watermark",
+                "Trendmark.SizedCRC32Trendmark",
                 invalidSize.toInt(),
                 invalidSize.toInt() - 1,
             ),
         )
         expectedStatus.addEvent(
             Trendmark.InvalidChecksumWarning(
-                "Trendmark.SizedCRC32Watermark",
+                "Trendmark.SizedCRC32Trendmark",
                 invalidCrc32,
                 expectedCrc32,
             ),
         )
 
         // Act
-        val watermark = SizedCRC32Watermark(watermarkContent)
+        val watermark = SizedCRC32Trendmark(watermarkContent)
         val extractedChecksum = watermark.extractChecksum()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -595,24 +595,24 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedSizedCRC32Watermark_creation_success() {
+    fun compressedSizedCRC32Trendmark_creation_success() {
         // Arrange
         val expectedSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedCRC32Watermark.SIZE_SIZE +
-                    SizedCRC32Watermark.CHECKSUM_SIZE +
+                    SizedCRC32Trendmark.SIZE_SIZE +
+                    SizedCRC32Trendmark.CHECKSUM_SIZE +
                     compressedContent.size
             ).toUInt()
         val expectedCrc32 = 0xD2A70713u
         val expected =
-            listOf(CompressedSizedCRC32Watermark.TYPE_TAG.toByte()) +
+            listOf(CompressedSizedCRC32Trendmark.TYPE_TAG.toByte()) +
                 expectedSize.toBytesLittleEndian() +
                 expectedCrc32.toBytesLittleEndian() +
                 compressedContent
 
         // Act
-        val watermark = CompressedSizedCRC32Watermark.new(content)
+        val watermark = CompressedSizedCRC32Trendmark.new(content)
         val extractedChecksum = watermark.extractChecksum()
         val extractedContent = watermark.getContent()
         val extractedSize = watermark.extractSize()
@@ -629,14 +629,14 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedSizedCRC32Watermark_invalidTag_error() {
+    fun compressedSizedCRC32Trendmark_invalidTag_error() {
         // Arrange
         val expectedCrc32 = 0x8E069413u
         val size =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedCRC32Watermark.SIZE_SIZE +
-                    SizedCRC32Watermark.CHECKSUM_SIZE +
+                    SizedCRC32Trendmark.SIZE_SIZE +
+                    SizedCRC32Trendmark.CHECKSUM_SIZE +
                     compressedContent.size
             ).toUInt()
         val watermarkContent =
@@ -646,13 +646,13 @@ class TrendmarkTest {
                 compressedContent
         val expectedStatus =
             Trendmark.InvalidTagError(
-                "Trendmark.CompressedSizedCRC32Watermark",
+                "Trendmark.CompressedSizedCRC32Trendmark",
                 251u,
                 255u,
             ).into().toString()
 
         // Act
-        val watermark = CompressedSizedCRC32Watermark(watermarkContent)
+        val watermark = CompressedSizedCRC32Trendmark(watermarkContent)
         val extractedChecksum = watermark.extractChecksum()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -668,41 +668,41 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedSizedCRC32Watermark_mismatchedSizeInvalidChecksum_warning() {
+    fun compressedSizedCRC32Trendmark_mismatchedSizeInvalidChecksum_warning() {
         // Arrange
         val expectedCrc32 = 0x4D7D848Du
         val invalidCrc32 = 0xFFFFFFFFu
         val invalidSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedCRC32Watermark.SIZE_SIZE +
-                    SizedCRC32Watermark.CHECKSUM_SIZE +
+                    SizedCRC32Trendmark.SIZE_SIZE +
+                    SizedCRC32Trendmark.CHECKSUM_SIZE +
                     compressedContent.size +
                     1
             ).toUInt()
         val watermarkContent =
-            listOf(CompressedSizedCRC32Watermark.TYPE_TAG.toByte()) +
+            listOf(CompressedSizedCRC32Trendmark.TYPE_TAG.toByte()) +
                 invalidSize.toBytesLittleEndian() +
                 invalidCrc32.toBytesLittleEndian() +
                 compressedContent
         val expectedStatus = Status.success()
         expectedStatus.addEvent(
             Trendmark.MismatchedSizeWarning(
-                "Trendmark.CompressedSizedCRC32Watermark",
+                "Trendmark.CompressedSizedCRC32Trendmark",
                 invalidSize.toInt(),
                 invalidSize.toInt() - 1,
             ),
         )
         expectedStatus.addEvent(
             Trendmark.InvalidChecksumWarning(
-                "Trendmark.CompressedSizedCRC32Watermark",
+                "Trendmark.CompressedSizedCRC32Trendmark",
                 invalidCrc32,
                 expectedCrc32,
             ),
         )
 
         // Act
-        val watermark = CompressedSizedCRC32Watermark(watermarkContent)
+        val watermark = CompressedSizedCRC32Trendmark(watermarkContent)
         val extractedChecksum = watermark.extractChecksum()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -718,7 +718,7 @@ class TrendmarkTest {
     }
 
     @Test
-    fun sha3256Watermark_creation_success() {
+    fun sha3256Trendmark_creation_success() {
         // Arrange
         val expectedHash =
             listOf<Byte>(
@@ -726,10 +726,10 @@ class TrendmarkTest {
                 -94, -86, 85, -77, -100, 43, 48, -74, 25, -34, 28, 17, -55, 80,
             )
         val expectedContent =
-            listOf(SHA3256Watermark.TYPE_TAG.toByte()) + expectedHash + content
+            listOf(SHA3256Trendmark.TYPE_TAG.toByte()) + expectedHash + content
 
         // Act
-        val watermark = SHA3256Watermark.new(content)
+        val watermark = SHA3256Trendmark.new(content)
         val extractedHash = watermark.extractHash()
         val extractedContent = watermark.getContent()
 
@@ -743,7 +743,7 @@ class TrendmarkTest {
     }
 
     @Test
-    fun sha3256Watermark_invalidTag_error() {
+    fun sha3256Trendmark_invalidTag_error() {
         // Arrange
         val expectedHash =
             listOf<Byte>(
@@ -752,7 +752,7 @@ class TrendmarkTest {
             )
         val expectedStatus =
             Trendmark.InvalidTagError(
-                "Trendmark.SHA3256Watermark",
+                "Trendmark.SHA3256Trendmark",
                 4u,
                 255u,
             ).into().toString()
@@ -761,7 +761,7 @@ class TrendmarkTest {
             listOf((-1).toByte()) + expectedHash + content
 
         // Act
-        val watermark = SHA3256Watermark(watermarkContent)
+        val watermark = SHA3256Trendmark(watermarkContent)
         val extractedHash = watermark.extractHash()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -777,7 +777,7 @@ class TrendmarkTest {
     }
 
     @Test
-    fun sha3256Watermark_invalidHash_warning() {
+    fun sha3256Trendmark_invalidHash_warning() {
         // Arrange
         val invalidHash = (0 until 32).map { it.toByte() }.toList()
         val expectedHash =
@@ -787,14 +787,14 @@ class TrendmarkTest {
             )
         val expectedStatus =
             Trendmark.InvalidHashWarning(
-                "Trendmark.SHA3256Watermark",
+                "Trendmark.SHA3256Trendmark",
                 invalidHash,
                 expectedHash,
             ).into()
-        val watermarkContent = listOf(SHA3256Watermark.TYPE_TAG.toByte()) + invalidHash + content
+        val watermarkContent = listOf(SHA3256Trendmark.TYPE_TAG.toByte()) + invalidHash + content
 
         // Act
-        val watermark = SHA3256Watermark(watermarkContent)
+        val watermark = SHA3256Trendmark(watermarkContent)
         val extractedHash = watermark.extractHash()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -810,7 +810,7 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedSHA3256Watermark_creation_success() {
+    fun compressedSHA3256Trendmark_creation_success() {
         // Arrange
         val expectedHash =
             listOf<Byte>(
@@ -818,10 +818,10 @@ class TrendmarkTest {
                 -104, -123, -91, -77, 62, -57, 71, -6, -120, 104, 116, -88, -17, 119, 91,
             )
         val expectedContent =
-            listOf(CompressedSHA3256Watermark.TYPE_TAG.toByte()) + expectedHash + compressedContent
+            listOf(CompressedSHA3256Trendmark.TYPE_TAG.toByte()) + expectedHash + compressedContent
 
         // Act
-        val watermark = CompressedSHA3256Watermark.new(content)
+        val watermark = CompressedSHA3256Trendmark.new(content)
         val extractedHash = watermark.extractHash()
         val extractedContent = watermark.getContent()
 
@@ -835,7 +835,7 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedSHA3256Watermark_invalidTag_error() {
+    fun compressedSHA3256Trendmark_invalidTag_error() {
         // Arrange
         val expectedHash =
             listOf<Byte>(
@@ -844,7 +844,7 @@ class TrendmarkTest {
             )
         val expectedStatus =
             Trendmark.InvalidTagError(
-                "Trendmark.CompressedSHA3256Watermark",
+                "Trendmark.CompressedSHA3256Trendmark",
                 250u,
                 255u,
             ).into().toString()
@@ -853,7 +853,7 @@ class TrendmarkTest {
             listOf((-1).toByte()) + expectedHash + compressedContent
 
         // Act
-        val watermark = CompressedSHA3256Watermark(watermarkContent)
+        val watermark = CompressedSHA3256Trendmark(watermarkContent)
         val extractedHash = watermark.extractHash()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -869,7 +869,7 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedSHA3256Watermark_invalidHash_warning() {
+    fun compressedSHA3256Trendmark_invalidHash_warning() {
         // Arrange
         val invalidHash = (0 until 32).map { it.toByte() }.toList()
         val expectedHash =
@@ -879,17 +879,17 @@ class TrendmarkTest {
             )
         val expectedStatus =
             Trendmark.InvalidHashWarning(
-                "Trendmark.CompressedSHA3256Watermark",
+                "Trendmark.CompressedSHA3256Trendmark",
                 invalidHash,
                 expectedHash,
             ).into()
         val watermarkContent =
-            listOf(CompressedSHA3256Watermark.TYPE_TAG.toByte()) +
+            listOf(CompressedSHA3256Trendmark.TYPE_TAG.toByte()) +
                 invalidHash +
                 compressedContent
 
         // Act
-        val watermark = CompressedSHA3256Watermark(watermarkContent)
+        val watermark = CompressedSHA3256Trendmark(watermarkContent)
         val extractedHash = watermark.extractHash()
         val extractedContent = watermark.getContent()
         val status = watermark.validate()
@@ -905,13 +905,13 @@ class TrendmarkTest {
     }
 
     @Test
-    fun sizedSha3256Watermark_creation_success() {
+    fun sizedSHA3256Trendmark_creation_success() {
         // Arrange
         val expectedSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedSHA3256Watermark.SIZE_SIZE +
-                    SizedSHA3256Watermark.HASH_SIZE +
+                    SizedSHA3256Trendmark.SIZE_SIZE +
+                    SizedSHA3256Trendmark.HASH_SIZE +
                     content.size
             ).toUInt()
         val expectedHash =
@@ -920,13 +920,13 @@ class TrendmarkTest {
                 53, -45, 52, -107, 92, 23, -125, -20, -20, 46, 73, 102, 69, -55, 26,
             )
         val expectedContent =
-            listOf(SizedSHA3256Watermark.TYPE_TAG.toByte()) +
+            listOf(SizedSHA3256Trendmark.TYPE_TAG.toByte()) +
                 expectedSize.toBytesLittleEndian() +
                 expectedHash +
                 content
 
         // Act
-        val watermark = SizedSHA3256Watermark.new(content)
+        val watermark = SizedSHA3256Trendmark.new(content)
         val extractedSize = watermark.extractSize()
         val extractedHash = watermark.extractHash()
         val extractedContent = watermark.getContent()
@@ -943,13 +943,13 @@ class TrendmarkTest {
     }
 
     @Test
-    fun sizedSha3256Watermark_invalidTag_error() {
+    fun sizedSHA3256Trendmark_invalidTag_error() {
         // Arrange
         val expectedSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedSHA3256Watermark.SIZE_SIZE +
-                    SizedSHA3256Watermark.HASH_SIZE +
+                    SizedSHA3256Trendmark.SIZE_SIZE +
+                    SizedSHA3256Trendmark.HASH_SIZE +
                     content.size
             ).toUInt()
         val expectedHash =
@@ -959,7 +959,7 @@ class TrendmarkTest {
             )
         val expectedStatus =
             Trendmark.InvalidTagError(
-                "Trendmark.SizedSHA3256Watermark",
+                "Trendmark.SizedSHA3256Trendmark",
                 5u,
                 255u,
             ).into().toString()
@@ -971,7 +971,7 @@ class TrendmarkTest {
                 content
 
         // Act
-        val watermark = SizedSHA3256Watermark(watermarkContent)
+        val watermark = SizedSHA3256Trendmark(watermarkContent)
         val extractedContent = watermark.getContent()
         val extractedSize = watermark.extractSize()
         val extractedHash = watermark.extractHash()
@@ -990,13 +990,13 @@ class TrendmarkTest {
     }
 
     @Test
-    fun sizedSha3256Watermark_mismatchedSizeInvalidHash_warning() {
+    fun sizedSHA3256Trendmark_mismatchedSizeInvalidHash_warning() {
         // Arrange
         val invalidSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedSHA3256Watermark.SIZE_SIZE +
-                    SizedSHA3256Watermark.HASH_SIZE +
+                    SizedSHA3256Trendmark.SIZE_SIZE +
+                    SizedSHA3256Trendmark.HASH_SIZE +
                     content.size +
                     1
             ).toUInt()
@@ -1009,27 +1009,27 @@ class TrendmarkTest {
         val expectedStatus = Status.success()
         expectedStatus.addEvent(
             Trendmark.MismatchedSizeWarning(
-                "Trendmark.SizedSHA3256Watermark",
+                "Trendmark.SizedSHA3256Trendmark",
                 invalidSize.toInt(),
                 invalidSize.toInt() - 1,
             ),
         )
         expectedStatus.addEvent(
             Trendmark.InvalidHashWarning(
-                "Trendmark.SizedSHA3256Watermark",
+                "Trendmark.SizedSHA3256Trendmark",
                 invalidHash,
                 expectedHash,
             ),
         )
 
         val watermarkContent =
-            listOf(SizedSHA3256Watermark.TYPE_TAG.toByte()) +
+            listOf(SizedSHA3256Trendmark.TYPE_TAG.toByte()) +
                 invalidSize.toBytesLittleEndian() +
                 invalidHash +
                 content
 
         // Act
-        val watermark = SizedSHA3256Watermark(watermarkContent)
+        val watermark = SizedSHA3256Trendmark(watermarkContent)
         val extractedContent = watermark.getContent()
         val extractedSize = watermark.extractSize()
         val extractedHash = watermark.extractHash()
@@ -1048,13 +1048,13 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedSizedSHA3256Watermark_creation_success() {
+    fun compressedSizedSHA3256Trendmark_creation_success() {
         // Arrange
         val expectedSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedSHA3256Watermark.SIZE_SIZE +
-                    SizedSHA3256Watermark.HASH_SIZE +
+                    SizedSHA3256Trendmark.SIZE_SIZE +
+                    SizedSHA3256Trendmark.HASH_SIZE +
                     compressedContent.size
             ).toUInt()
         val expectedHash =
@@ -1063,13 +1063,13 @@ class TrendmarkTest {
                 -28, 68, -118, 65, -44, -115, 94, -63, -103, -120, -78, -17, -125, -56, 110,
             )
         val expectedContent =
-            listOf(CompressedSizedSHA3256Watermark.TYPE_TAG.toByte()) +
+            listOf(CompressedSizedSHA3256Trendmark.TYPE_TAG.toByte()) +
                 expectedSize.toBytesLittleEndian() +
                 expectedHash +
                 compressedContent
 
         // Act
-        val watermark = CompressedSizedSHA3256Watermark.new(content)
+        val watermark = CompressedSizedSHA3256Trendmark.new(content)
         val extractedSize = watermark.extractSize()
         val extractedHash = watermark.extractHash()
         val extractedContent = watermark.getContent()
@@ -1086,13 +1086,13 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedSizedSHA3256Watermark_invalidTag_error() {
+    fun compressedSizedSHA3256Trendmark_invalidTag_error() {
         // Arrange
         val expectedSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedSHA3256Watermark.SIZE_SIZE +
-                    SizedSHA3256Watermark.HASH_SIZE +
+                    SizedSHA3256Trendmark.SIZE_SIZE +
+                    SizedSHA3256Trendmark.HASH_SIZE +
                     compressedContent.size
             ).toUInt()
         val expectedHash =
@@ -1102,7 +1102,7 @@ class TrendmarkTest {
             )
         val expectedStatus =
             Trendmark.InvalidTagError(
-                "Trendmark.CompressedSizedSHA3256Watermark",
+                "Trendmark.CompressedSizedSHA3256Trendmark",
                 249u,
                 255u,
             ).into().toString()
@@ -1114,7 +1114,7 @@ class TrendmarkTest {
                 compressedContent
 
         // Act
-        val watermark = CompressedSizedSHA3256Watermark(watermarkContent)
+        val watermark = CompressedSizedSHA3256Trendmark(watermarkContent)
         val extractedContent = watermark.getContent()
         val extractedSize = watermark.extractSize()
         val extractedHash = watermark.extractHash()
@@ -1133,13 +1133,13 @@ class TrendmarkTest {
     }
 
     @Test
-    fun compressedSizedSHA3256Watermark_mismatchedSizeInvalidHash_warning() {
+    fun compressedSizedSHA3256Trendmark_mismatchedSizeInvalidHash_warning() {
         // Arrange
         val invalidSize =
             (
                 TrendmarkInterface.TAG_SIZE +
-                    SizedSHA3256Watermark.SIZE_SIZE +
-                    SizedSHA3256Watermark.HASH_SIZE +
+                    SizedSHA3256Trendmark.SIZE_SIZE +
+                    SizedSHA3256Trendmark.HASH_SIZE +
                     compressedContent.size +
                     1
             ).toUInt()
@@ -1152,27 +1152,27 @@ class TrendmarkTest {
         val expectedStatus = Status.success()
         expectedStatus.addEvent(
             Trendmark.MismatchedSizeWarning(
-                "Trendmark.CompressedSizedSHA3256Watermark",
+                "Trendmark.CompressedSizedSHA3256Trendmark",
                 invalidSize.toInt(),
                 invalidSize.toInt() - 1,
             ),
         )
         expectedStatus.addEvent(
             Trendmark.InvalidHashWarning(
-                "Trendmark.CompressedSizedSHA3256Watermark",
+                "Trendmark.CompressedSizedSHA3256Trendmark",
                 invalidHash,
                 expectedHash,
             ),
         )
 
         val watermarkContent =
-            listOf(CompressedSizedSHA3256Watermark.TYPE_TAG.toByte()) +
+            listOf(CompressedSizedSHA3256Trendmark.TYPE_TAG.toByte()) +
                 invalidSize.toBytesLittleEndian() +
                 invalidHash +
                 compressedContent
 
         // Act
-        val watermark = CompressedSizedSHA3256Watermark(watermarkContent)
+        val watermark = CompressedSizedSHA3256Trendmark(watermarkContent)
         val extractedContent = watermark.getContent()
         val extractedSize = watermark.extractSize()
         val extractedHash = watermark.extractHash()
@@ -1193,186 +1193,186 @@ class TrendmarkTest {
     @Test
     fun parse_valid_success() {
         // Arrange
-        val rawWatermark = RawWatermark.new(content)
-        val sizedWatermark = SizedWatermark.new(content)
-        val crc32Watermark = CRC32Watermark.new(content)
-        val sizedCRC32Watermark = SizedCRC32Watermark.new(content)
-        val sha3256Watermark = SHA3256Watermark.new(content)
-        val sizedSHA3256Watermark = SizedSHA3256Watermark.new(content)
-        val compressedRawWatermark = CompressedRawWatermark.new(content)
-        val compressedSizedWatermark = CompressedSizedWatermark.new(content)
-        val compressedCRC32Watermark = CompressedCRC32Watermark.new(content)
-        val compressedSizedCRC32Watermark = CompressedSizedCRC32Watermark.new(content)
-        val compressedSHA3256Watermark = CompressedSHA3256Watermark.new(content)
-        val compressedSizedSHA3256Watermark = CompressedSizedSHA3256Watermark.new(content)
+        val rawTrendmark = RawTrendmark.new(content)
+        val sizedTrendmark = SizedTrendmark.new(content)
+        val crc32Trendmark = CRC32Trendmark.new(content)
+        val sizedCRC32Trendmark = SizedCRC32Trendmark.new(content)
+        val sha3256Trendmark = SHA3256Trendmark.new(content)
+        val sizedSHA3256Trendmark = SizedSHA3256Trendmark.new(content)
+        val compressedRawTrendmark = CompressedRawTrendmark.new(content)
+        val compressedSizedTrendmark = CompressedSizedTrendmark.new(content)
+        val compressedCRC32Trendmark = CompressedCRC32Trendmark.new(content)
+        val compressedSizedCRC32Trendmark = CompressedSizedCRC32Trendmark.new(content)
+        val compressedSHA3256Trendmark = CompressedSHA3256Trendmark.new(content)
+        val compressedSizedSHA3256Trendmark = CompressedSizedSHA3256Trendmark.new(content)
 
         // Act
-        val parsedPlainWatermark = Trendmark.parse(rawWatermark.watermarkContent)
-        val parsedSizedWatermark = Trendmark.parse(sizedWatermark.watermarkContent)
-        val parsedCRC32Watermark = Trendmark.parse(crc32Watermark.watermarkContent)
-        val parsedSizedCRC32Watermark = Trendmark.parse(sizedCRC32Watermark.watermarkContent)
-        val parsedSHA3256Watermark = Trendmark.parse(sha3256Watermark.watermarkContent)
-        val parsedSizedSHA3256Watermark = Trendmark.parse(sizedSHA3256Watermark.watermarkContent)
-        val parsedCompressedRawWatermark = Trendmark.parse(compressedRawWatermark.watermarkContent)
-        val parsedCompressedSizedWatermark =
-            Trendmark.parse(compressedSizedWatermark.watermarkContent)
-        val parsedCompressedCRC32Watermark =
-            Trendmark.parse(compressedCRC32Watermark.watermarkContent)
-        val parsedCompressedSizedCRC32Watermark =
-            Trendmark.parse(compressedSizedCRC32Watermark.watermarkContent)
-        val parsedCompressedSHA3256Watermark =
-            Trendmark.parse(compressedSHA3256Watermark.watermarkContent)
-        val parsedCompressedSizedSHA3256Watermark =
-            Trendmark.parse(compressedSizedSHA3256Watermark.watermarkContent)
+        val parsedPlainWatermark = Trendmark.parse(rawTrendmark.watermarkContent)
+        val parsedSizedTrendmark = Trendmark.parse(sizedTrendmark.watermarkContent)
+        val parsedCRC32Trendmark = Trendmark.parse(crc32Trendmark.watermarkContent)
+        val parsedSizedCRC32Trendmark = Trendmark.parse(sizedCRC32Trendmark.watermarkContent)
+        val parsedSHA3256Trendmark = Trendmark.parse(sha3256Trendmark.watermarkContent)
+        val parsedSizedSHA3256Trendmark = Trendmark.parse(sizedSHA3256Trendmark.watermarkContent)
+        val parsedCompressedRawTrendmark = Trendmark.parse(compressedRawTrendmark.watermarkContent)
+        val parsedCompressedSizedTrendmark =
+            Trendmark.parse(compressedSizedTrendmark.watermarkContent)
+        val parsedCompressedCRC32Trendmark =
+            Trendmark.parse(compressedCRC32Trendmark.watermarkContent)
+        val parsedCompressedSizedCRC32Trendmark =
+            Trendmark.parse(compressedSizedCRC32Trendmark.watermarkContent)
+        val parsedCompressedSHA3256Trendmark =
+            Trendmark.parse(compressedSHA3256Trendmark.watermarkContent)
+        val parsedCompressedSizedSHA3256Trendmark =
+            Trendmark.parse(compressedSizedSHA3256Trendmark.watermarkContent)
 
         // Assert
         assertTrue(parsedPlainWatermark.isSuccess)
         var parsedWatermark = parsedPlainWatermark.value!!
-        assertTrue(parsedWatermark is RawWatermark)
+        assertTrue(parsedWatermark is RawTrendmark)
         assertEquals(content, parsedWatermark.getContent().value)
-        assertEquals(rawWatermark.watermarkContent, parsedWatermark.watermarkContent)
+        assertEquals(rawTrendmark.watermarkContent, parsedWatermark.watermarkContent)
         assertTrue(parsedWatermark.validate().isSuccess)
 
-        assertTrue(parsedSizedWatermark.isSuccess)
-        parsedWatermark = parsedSizedWatermark.value!!
-        assertTrue(parsedWatermark is SizedWatermark)
-        assertEquals(sizedWatermark.extractSize().value!!, parsedWatermark.extractSize().value!!)
+        assertTrue(parsedSizedTrendmark.isSuccess)
+        parsedWatermark = parsedSizedTrendmark.value!!
+        assertTrue(parsedWatermark is SizedTrendmark)
+        assertEquals(sizedTrendmark.extractSize().value!!, parsedWatermark.extractSize().value!!)
         assertEquals(content, parsedWatermark.getContent().value)
-        assertEquals(sizedWatermark.watermarkContent, parsedWatermark.watermarkContent)
+        assertEquals(sizedTrendmark.watermarkContent, parsedWatermark.watermarkContent)
         assertTrue(parsedWatermark.validate().isSuccess)
 
-        assertTrue(parsedCRC32Watermark.isSuccess)
-        parsedWatermark = parsedCRC32Watermark.value!!
-        assertTrue(parsedWatermark is CRC32Watermark)
+        assertTrue(parsedCRC32Trendmark.isSuccess)
+        parsedWatermark = parsedCRC32Trendmark.value!!
+        assertTrue(parsedWatermark is CRC32Trendmark)
         assertEquals(
-            crc32Watermark.extractChecksum().value!!,
+            crc32Trendmark.extractChecksum().value!!,
             parsedWatermark.extractChecksum().value!!,
         )
         assertEquals(content, parsedWatermark.getContent().value)
-        assertEquals(crc32Watermark.watermarkContent, parsedWatermark.watermarkContent)
+        assertEquals(crc32Trendmark.watermarkContent, parsedWatermark.watermarkContent)
 
-        assertTrue(parsedSizedCRC32Watermark.isSuccess)
-        parsedWatermark = parsedSizedCRC32Watermark.value!!
-        assertTrue(parsedWatermark is SizedCRC32Watermark)
+        assertTrue(parsedSizedCRC32Trendmark.isSuccess)
+        parsedWatermark = parsedSizedCRC32Trendmark.value!!
+        assertTrue(parsedWatermark is SizedCRC32Trendmark)
         assertEquals(
-            sizedCRC32Watermark.extractSize().value!!,
+            sizedCRC32Trendmark.extractSize().value!!,
             parsedWatermark.extractSize().value!!,
         )
         assertEquals(
-            sizedCRC32Watermark.extractChecksum().value!!,
+            sizedCRC32Trendmark.extractChecksum().value!!,
             parsedWatermark.extractChecksum().value!!,
         )
         assertEquals(content, parsedWatermark.getContent().value)
-        assertEquals(sizedCRC32Watermark.watermarkContent, parsedWatermark.watermarkContent)
+        assertEquals(sizedCRC32Trendmark.watermarkContent, parsedWatermark.watermarkContent)
         assertTrue(parsedWatermark.validate().isSuccess)
 
-        assertTrue(parsedSHA3256Watermark.isSuccess)
-        parsedWatermark = parsedSHA3256Watermark.value!!
-        assertTrue(parsedWatermark is SHA3256Watermark)
-        assertEquals(sha3256Watermark.extractHash().value!!, parsedWatermark.extractHash().value!!)
+        assertTrue(parsedSHA3256Trendmark.isSuccess)
+        parsedWatermark = parsedSHA3256Trendmark.value!!
+        assertTrue(parsedWatermark is SHA3256Trendmark)
+        assertEquals(sha3256Trendmark.extractHash().value!!, parsedWatermark.extractHash().value!!)
         assertEquals(content, parsedWatermark.getContent().value)
-        assertEquals(sha3256Watermark.watermarkContent, parsedWatermark.watermarkContent)
+        assertEquals(sha3256Trendmark.watermarkContent, parsedWatermark.watermarkContent)
         assertTrue(parsedWatermark.validate().isSuccess)
 
-        assertTrue(parsedSizedSHA3256Watermark.isSuccess)
-        parsedWatermark = parsedSizedSHA3256Watermark.value!!
-        assertTrue(parsedWatermark is SizedSHA3256Watermark)
+        assertTrue(parsedSizedSHA3256Trendmark.isSuccess)
+        parsedWatermark = parsedSizedSHA3256Trendmark.value!!
+        assertTrue(parsedWatermark is SizedSHA3256Trendmark)
         assertEquals(
-            sizedSHA3256Watermark.extractSize().value!!,
+            sizedSHA3256Trendmark.extractSize().value!!,
             parsedWatermark.extractSize().value!!,
         )
         assertEquals(
-            sizedSHA3256Watermark.extractHash().value!!,
+            sizedSHA3256Trendmark.extractHash().value!!,
             parsedWatermark.extractHash().value!!,
         )
         assertEquals(content, parsedWatermark.getContent().value)
-        assertEquals(sizedSHA3256Watermark.watermarkContent, parsedWatermark.watermarkContent)
+        assertEquals(sizedSHA3256Trendmark.watermarkContent, parsedWatermark.watermarkContent)
         assertTrue(parsedWatermark.validate().isSuccess)
 
-        assertTrue(parsedCompressedRawWatermark.isSuccess)
-        parsedWatermark = parsedCompressedRawWatermark.value!!
-        assertTrue(parsedWatermark is CompressedRawWatermark)
+        assertTrue(parsedCompressedRawTrendmark.isSuccess)
+        parsedWatermark = parsedCompressedRawTrendmark.value!!
+        assertTrue(parsedWatermark is CompressedRawTrendmark)
         var decompressedContent = parsedWatermark.getContent()
         assertTrue(decompressedContent.isSuccess)
         assertEquals(content, decompressedContent.value)
-        assertEquals(compressedRawWatermark.watermarkContent, parsedWatermark.watermarkContent)
+        assertEquals(compressedRawTrendmark.watermarkContent, parsedWatermark.watermarkContent)
         assertTrue(parsedWatermark.validate().isSuccess)
 
-        assertTrue(parsedCompressedSizedWatermark.isSuccess)
-        parsedWatermark = parsedCompressedSizedWatermark.value!!
-        assertTrue(parsedWatermark is CompressedSizedWatermark)
+        assertTrue(parsedCompressedSizedTrendmark.isSuccess)
+        parsedWatermark = parsedCompressedSizedTrendmark.value!!
+        assertTrue(parsedWatermark is CompressedSizedTrendmark)
         decompressedContent = parsedWatermark.getContent()
         assertTrue(decompressedContent.isSuccess)
         assertEquals(content, decompressedContent.value)
         assertEquals(
-            compressedSizedWatermark.extractSize().value!!,
+            compressedSizedTrendmark.extractSize().value!!,
             parsedWatermark.extractSize().value!!,
         )
-        assertEquals(compressedSizedWatermark.watermarkContent, parsedWatermark.watermarkContent)
+        assertEquals(compressedSizedTrendmark.watermarkContent, parsedWatermark.watermarkContent)
         assertTrue(parsedWatermark.validate().isSuccess)
 
-        assertTrue(parsedCompressedCRC32Watermark.isSuccess)
-        parsedWatermark = parsedCompressedCRC32Watermark.value!!
-        assertTrue(parsedWatermark is CompressedCRC32Watermark)
+        assertTrue(parsedCompressedCRC32Trendmark.isSuccess)
+        parsedWatermark = parsedCompressedCRC32Trendmark.value!!
+        assertTrue(parsedWatermark is CompressedCRC32Trendmark)
         decompressedContent = parsedWatermark.getContent()
         assertTrue(decompressedContent.isSuccess)
         assertEquals(content, decompressedContent.value)
         assertEquals(
-            compressedCRC32Watermark.extractChecksum().value!!,
+            compressedCRC32Trendmark.extractChecksum().value!!,
             parsedWatermark.extractChecksum().value!!,
         )
-        assertEquals(compressedCRC32Watermark.watermarkContent, parsedWatermark.watermarkContent)
+        assertEquals(compressedCRC32Trendmark.watermarkContent, parsedWatermark.watermarkContent)
         assertTrue(parsedWatermark.validate().isSuccess)
 
-        assertTrue(parsedCompressedSizedCRC32Watermark.isSuccess)
-        parsedWatermark = parsedCompressedSizedCRC32Watermark.value!!
-        assertTrue(parsedWatermark is CompressedSizedCRC32Watermark)
+        assertTrue(parsedCompressedSizedCRC32Trendmark.isSuccess)
+        parsedWatermark = parsedCompressedSizedCRC32Trendmark.value!!
+        assertTrue(parsedWatermark is CompressedSizedCRC32Trendmark)
         decompressedContent = parsedWatermark.getContent()
         assertTrue(decompressedContent.isSuccess)
         assertEquals(content, decompressedContent.value)
         assertEquals(
-            compressedSizedCRC32Watermark.extractSize().value!!,
+            compressedSizedCRC32Trendmark.extractSize().value!!,
             parsedWatermark.extractSize().value!!,
         )
         assertEquals(
-            compressedSizedCRC32Watermark.extractChecksum().value!!,
+            compressedSizedCRC32Trendmark.extractChecksum().value!!,
             parsedWatermark.extractChecksum().value!!,
         )
         assertEquals(
-            compressedSizedCRC32Watermark.watermarkContent,
+            compressedSizedCRC32Trendmark.watermarkContent,
             parsedWatermark.watermarkContent,
         )
         assertTrue(parsedWatermark.validate().isSuccess)
 
-        assertTrue(parsedCompressedSHA3256Watermark.isSuccess)
-        parsedWatermark = parsedCompressedSHA3256Watermark.value!!
-        assertTrue(parsedWatermark is CompressedSHA3256Watermark)
+        assertTrue(parsedCompressedSHA3256Trendmark.isSuccess)
+        parsedWatermark = parsedCompressedSHA3256Trendmark.value!!
+        assertTrue(parsedWatermark is CompressedSHA3256Trendmark)
         decompressedContent = parsedWatermark.getContent()
         assertTrue(decompressedContent.isSuccess)
         assertEquals(content, decompressedContent.value)
         assertEquals(
-            compressedSHA3256Watermark.extractHash().value!!,
+            compressedSHA3256Trendmark.extractHash().value!!,
             parsedWatermark.extractHash().value!!,
         )
-        assertEquals(compressedSHA3256Watermark.watermarkContent, parsedWatermark.watermarkContent)
+        assertEquals(compressedSHA3256Trendmark.watermarkContent, parsedWatermark.watermarkContent)
         assertTrue(parsedWatermark.validate().isSuccess)
 
-        assertTrue(parsedCompressedSizedSHA3256Watermark.isSuccess)
-        parsedWatermark = parsedCompressedSizedSHA3256Watermark.value!!
-        assertTrue(parsedWatermark is CompressedSizedSHA3256Watermark)
+        assertTrue(parsedCompressedSizedSHA3256Trendmark.isSuccess)
+        parsedWatermark = parsedCompressedSizedSHA3256Trendmark.value!!
+        assertTrue(parsedWatermark is CompressedSizedSHA3256Trendmark)
         decompressedContent = parsedWatermark.getContent()
         assertTrue(decompressedContent.isSuccess)
         assertEquals(content, decompressedContent.value)
         assertEquals(
-            compressedSizedSHA3256Watermark.extractSize().value!!,
+            compressedSizedSHA3256Trendmark.extractSize().value!!,
             parsedWatermark.extractSize().value!!,
         )
         assertEquals(
-            compressedSizedSHA3256Watermark.extractHash().value!!,
+            compressedSizedSHA3256Trendmark.extractHash().value!!,
             parsedWatermark.extractHash().value!!,
         )
         assertEquals(
-            compressedSizedSHA3256Watermark.watermarkContent,
+            compressedSizedSHA3256Trendmark.watermarkContent,
             parsedWatermark.watermarkContent,
         )
         assertTrue(parsedWatermark.validate().isSuccess)


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->
Renames all variants of `Trendmark` so that they end on `Trendmark` instead of `Watermark`.

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #79

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
