### PR TITLE
feat(watermarker): add dedicated getContentAsString() function to Watermark class

### DIFF
--- a/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
@@ -196,7 +196,7 @@ sealed class Trendmark(
 
     /** Represents the Trendmark in a human-readable form */
     override fun toString(): String {
-        return "${getSource()}(${super.toString()})"
+        return "${getSource()}(${super.getContentAsText()})"
     }
 
     sealed interface Sized : TrendmarkInterface {

--- a/watermarker/src/commonMain/kotlin/watermarks/Watermark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Watermark.kt
@@ -19,8 +19,13 @@ open class Watermark(var watermarkContent: List<Byte>) {
         }
     }
 
-    /** Represents the bytes of the watermark in hex */
-    override fun toString(): String = watermarkContent.toHexString()
+    /** Represents the bytes of the Watermark in hex */
+    fun getContentAsText(): String = watermarkContent.toHexString()
+
+    /** Represents the Watermark in a human-readable form */
+    override fun toString(): String {
+        return "Watermark(${this.getContentAsText()})"
+    }
 
     /** Returns true if other is a watermark and contains the same bytes */
     override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->

Adds a decicated `getContentAsString()` function to the `Watermark` class as demanded in #95. The `toString()` method of said class is refactored to meet its actual purpose of creating a human-readable string to represent the object.

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #95

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
