### PR TITLE
feat(watermarker): add functionality to only compress if size is decreased

### DIFF
--- a/watermarker/src/commonMain/kotlin/watermarks/TextWatermark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/TextWatermark.kt
@@ -50,6 +50,20 @@ class TextWatermark private constructor(
         /** Creates a TextWatermark from [text] with compression but without size information */
         fun compressed(text: String): TextWatermark = TextWatermark(text, compressed = true)
 
+        /** Creates a TextWatermark from [text] with compression only if compression decreases the size */
+        fun small(text: String): TextWatermark {
+            val raw = TextWatermark(text)
+            val rawSize = raw.finish().watermarkContent.size
+            val compressed = TextWatermark(text, compressed = true)
+            val compressedSize = compressed.finish().watermarkContent.size
+
+            return if (rawSize < compressedSize) {
+                raw
+            } else {
+                compressed
+            }
+        }
+
         /** Creates a TextWatermark from [text] with size information but without compression */
         fun sized(text: String): TextWatermark = TextWatermark(text, sized = true)
 

--- a/watermarker/src/commonMain/kotlin/watermarks/TextWatermark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/TextWatermark.kt
@@ -52,9 +52,9 @@ class TextWatermark private constructor(
 
         /** Creates a TextWatermark from [text] with compression only if compression decreases the size */
         fun small(text: String): TextWatermark {
-            val raw = TextWatermark(text)
+            val raw = TextWatermark.raw(text)
             val rawSize = raw.finish().watermarkContent.size
-            val compressed = TextWatermark(text, compressed = true)
+            val compressed = TextWatermark.compressed(text)
             val compressedSize = compressed.finish().watermarkContent.size
 
             return if (rawSize < compressedSize) {

--- a/watermarker/src/commonTest/kotlin/unitTest/watermarks/TextWatermarkTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/watermarks/TextWatermarkTest.kt
@@ -69,6 +69,50 @@ class TextWatermarkTest {
     }
 
     @Test
+    fun small_loremIpsum_compression() {
+        val customText = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr"
+        val customTextBytes = customText.encodeToByteArray().asList()
+
+        // Arrange
+        val expectedTrendmark = CompressedRawTrendmark.new(customTextBytes)
+
+        // Act
+        val textWatermark = TextWatermark.small(customText)
+        val trendmark = textWatermark.finish()
+        val content = trendmark.getContent()
+
+        // Assert
+        assertEquals(customText, textWatermark.text)
+        assertFalse(textWatermark.isSized())
+        assertTrue(textWatermark.isCompressed())
+        assertEquals(expectedTrendmark, trendmark)
+        assertTrue(content.isSuccess)
+        assertEquals(customTextBytes, content.value)
+    }
+
+    @Test
+    fun small_loremIpsum_noCompression() {
+        val customText = "Lorem"
+        val customTextBytes = customText.encodeToByteArray().asList()
+
+        // Arrange
+        val expectedTrendmark = RawTrendmark.new(customTextBytes)
+
+        // Act
+        val textWatermark = TextWatermark.small(customText)
+        val trendmark = textWatermark.finish()
+        val content = trendmark.getContent()
+
+        // Assert
+        assertEquals(customText, textWatermark.text)
+        assertFalse(textWatermark.isSized())
+        assertFalse(textWatermark.isCompressed())
+        assertEquals(expectedTrendmark, trendmark)
+        assertTrue(content.isSuccess)
+        assertEquals(customTextBytes, content.value)
+    }
+
+    @Test
     fun sized_loremIpsum_success() {
         // Arrange
         val expectedTrendmark = SizedTrendmark.new(textBytes)

--- a/watermarker/src/commonTest/kotlin/unitTest/watermarks/TextWatermarkTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/watermarks/TextWatermarkTest.kt
@@ -70,10 +70,9 @@ class TextWatermarkTest {
 
     @Test
     fun small_loremIpsum_compression() {
+        // Arrange
         val customText = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr"
         val customTextBytes = customText.encodeToByteArray().asList()
-
-        // Arrange
         val expectedTrendmark = CompressedRawTrendmark.new(customTextBytes)
 
         // Act
@@ -92,10 +91,9 @@ class TextWatermarkTest {
 
     @Test
     fun small_loremIpsum_noCompression() {
+        // Arrange
         val customText = "Lorem"
         val customTextBytes = customText.encodeToByteArray().asList()
-
-        // Arrange
         val expectedTrendmark = RawTrendmark.new(customTextBytes)
 
         // Act


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->

Adds a convenience function to create a `Trendmark` that is only compressed if the compression decreases the size of the content as demanded by option [1] of #98.

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #98 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
