### PR TITLE
feat: added function to get content of a trendmark as string immediately

### DIFF
--- a/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
@@ -49,6 +49,16 @@ sealed interface TrendmarkInterface {
     /** Returns the raw bytes of the watermark */
     fun getRawContent(): List<Byte>
 
+    /** Returns the decoded information stored in the Trendmark as a string*/
+    fun getContentAsString(): Result<String> {
+        val content =
+            with(getContent()) {
+                if (!isSuccess) return status.into<_>()
+                value!!
+            }
+        return Result.success(content.toByteArray().decodeToString())
+    }
+
     /** Updates the raw bytes of the watermark */
     fun setRawContent(content: List<Byte>)
 

--- a/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
@@ -49,16 +49,6 @@ sealed interface TrendmarkInterface {
     /** Returns the raw bytes of the watermark */
     fun getRawContent(): List<Byte>
 
-    /** Returns the decoded information stored in the Trendmark as a string*/
-    fun getContentAsString(): Result<String> {
-        val content =
-            with(getContent()) {
-                if (!isSuccess) return status.into<_>()
-                value!!
-            }
-        return Result.success(content.toByteArray().decodeToString())
-    }
-
     /** Updates the raw bytes of the watermark */
     fun setRawContent(content: List<Byte>)
 
@@ -176,6 +166,16 @@ sealed class Trendmark(
 
     /** Returns the all bytes of the watermark */
     override fun getRawContent(): List<Byte> = watermarkContent
+
+    /** Returns the decoded information stored in the Trendmark as a string*/
+    fun getContentAsString(): Result<String> {
+        val content =
+            with(getContent()) {
+                if (!isSuccess) return status.into<_>()
+                value!!
+            }
+        return Result.success(content.toByteArray().decodeToString())
+    }
 
     /** Sets all bytes of the watermark to [content] */
     override fun setRawContent(content: List<Byte>) {

--- a/watermarker/src/commonTest/kotlin/unitTest/watermarks/TrendmarkTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/watermarks/TrendmarkTest.kt
@@ -1503,5 +1503,46 @@ class TrendmarkTest {
 
         // Assert
         assertEquals(expected, result)
+        assertTrue(false)
+    }
+
+    @Test
+    fun trendmark_parseableBytes_contentAsString() {
+        // Arrange
+        val expected = "Lorem Ipsum"
+        val watermark = RawTrendmark.new(content)
+
+        // Act
+        val extractedContent = watermark.getContentAsString()
+
+        // Assert
+        assertTrue(extractedContent.isSuccess)
+        assertEquals(expected, extractedContent.value)
+    }
+
+    @Test
+    fun trendmark_unparseableBytes_contentAsString_gracefull() {
+        // Arrange
+        val expected = "\uFFFD"
+        val watermark = RawTrendmark.new(listOf<Byte>(195.toByte()))
+
+        // Act
+        val extractedContent = watermark.getContentAsString(errorOnInvalidUTF8 = false)
+
+        // Assert
+        assertTrue(extractedContent.isSuccess)
+        assertEquals(expected, extractedContent.value)
+    }
+
+    @Test
+    fun trendmark_unparseableBytes_contentAsString_throwError() {
+        // Arrange
+        val watermark = RawTrendmark.new(listOf<Byte>(195.toByte()))
+
+        // Act
+        val extractedContent = watermark.getContentAsString(errorOnInvalidUTF8 = true)
+
+        // Assert
+        assertTrue(extractedContent.isError)
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->

This PR adds a convenience function to the Trendmark Interface that returns the content of the Trendmark as a string (instead of a byte list).

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #107 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
