### PR TITLE
fix(watermarker): update TextWatermarkerBuilder validation for StartEnd strategy

### DIFF
--- a/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
@@ -192,7 +192,7 @@ class TextWatermarker(
         return Success(startPositions).into()
     }
 
-    /** Checks if [file] contains a watermark */
+    /** Checks if [file] contains any [Char] from full watermarking alphabet */
     override fun containsWatermark(file: TextFile): Boolean =
         file.content.any { char ->
             char in fullAlphabet
@@ -472,8 +472,8 @@ class TextWatermarkerBuilder {
                 if (separatorStrategy.start in transcoding.alphabet) {
                     list.add(separatorStrategy.start)
                 }
-                if (separatorStrategy.start in transcoding.alphabet) {
-                    list.add(separatorStrategy.start)
+                if (separatorStrategy.end in transcoding.alphabet) {
+                    list.add(separatorStrategy.end)
                 }
                 if (!list.isEmpty()) {
                     status.addEvent(AlphabetContainsSeparatorError(list))

--- a/watermarker/src/commonTest/kotlin/unitTest/fileWatermarker/TextWatermarkerTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/fileWatermarker/TextWatermarkerTest.kt
@@ -206,11 +206,6 @@ class TextWatermarkerBuilderTest {
         assertNull(result.value)
     }
 
-    /**
-     * tests if the validate() function of the builder will correctly return an error when
-     * either Separator in the StartEnd Strategy is an illegal Char, as well as when both the
-     * Start and End Char are illegal
-     */
     @Test
     fun buildSecondStrategy_alphabetContainsSeparatorChar_error() {
         // Arrange

--- a/watermarker/src/commonTest/kotlin/unitTest/fileWatermarker/TextWatermarkerTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/fileWatermarker/TextWatermarkerTest.kt
@@ -206,6 +206,64 @@ class TextWatermarkerBuilderTest {
         assertNull(result.value)
     }
 
+    /**
+     * tests if the validate() function of the builder will correctly return an error when
+     * either Separator in the StartEnd Strategy is an illegal Char, as well as when both the
+     * Start and End Char are illegal
+     */
+    @Test
+    fun buildSecondStrategy_alphabetContainsSeparatorChar_error() {
+        // Arrange
+        val alphabetChar1 = DefaultTranscoding.alphabet[0]
+        val alphabetChar2 = DefaultTranscoding.alphabet[1]
+        val validChar = '\u3164' // hangul filler, chosen at random
+        val errorEither =
+            TextWatermarkerBuilder.AlphabetContainsSeparatorError(listOf(alphabetChar1))
+        val errorBoth =
+            TextWatermarkerBuilder.AlphabetContainsSeparatorError(
+                listOf(alphabetChar1, alphabetChar2),
+            )
+        val expectedEither = errorEither.getMessage()
+        val expectedBoth = errorBoth.getMessage()
+
+        // Act
+        val resultStart =
+            TextWatermarker
+                .builder()
+                .setSeparatorStrategy(
+                    SeparatorStrategy.StartEndSeparatorChars(alphabetChar1, validChar),
+                )
+                .build()
+        val resultEnd =
+            TextWatermarker
+                .builder()
+                .setSeparatorStrategy(
+                    SeparatorStrategy.StartEndSeparatorChars(validChar, alphabetChar1),
+                )
+                .build()
+        val resultBoth =
+            TextWatermarker
+                .builder()
+                .setSeparatorStrategy(
+                    SeparatorStrategy.StartEndSeparatorChars(alphabetChar1, alphabetChar2),
+                )
+                .build()
+
+        // Assert
+        // Start char assertions
+        assertTrue(resultStart.isError)
+        assertEquals(expectedEither, resultStart.getMessage())
+        assertNull(resultStart.value)
+        // End char assertions
+        assertTrue(resultEnd.isError)
+        assertEquals(expectedEither, resultEnd.getMessage())
+        assertNull(resultEnd.value)
+        // Both char assertions
+        assertTrue(resultBoth.isError)
+        assertEquals(expectedBoth, resultBoth.getMessage())
+        assertNull(resultBoth.value)
+    }
+
     @Test
     fun alphabetContainsSeparatorCharError_string_success() {
         // Arrange


### PR DESCRIPTION
## Description
Update the TextWatermarkerBuilder class's validate function in TextWatermarker file to correctly check both Chars in the StartEnd strategy as well as adding corresponding test in TextWatermarkerTest.

## Linked Issue(s)
Fixes #127 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
