### PR TITLE
feat(watermarker): extend Trendmark support in TextWatermark

### DIFF
--- a/watermarker/src/commonMain/kotlin/watermarks/TextWatermark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/TextWatermark.kt
@@ -17,9 +17,9 @@ import kotlin.jvm.JvmName
  * text as content.
  *
  * TextWatermark can be instantiated using the companion functions. The functions `new`, `raw`,
- * `compressed`, `sized`, `checked`, `hashed`, `compressedAndSized`, `compressedAndChecked`,
- * `compressedAndHashed`, `sizedAndChecked`, `sizedAndHashed`, `compressedSizedChecked` and
- * `compressedSizedHashed` allows creation of a new TextWatermark from a String and specifying
+ * `compressed`, `sized`, `CRC32`, `SHA3256`, `compressedSized`, `compressedCRC32`,
+ * `compressedSHA3256`, `sizedCRC32`, `sizedSHA3256`, `compressedSizedCRC32` and
+ * `compressedSizedSHA3256` allows creation of a new TextWatermark from a String and specifying
  * the format of the produced Trendmark.
  *
  * The function `fromTrendmark` allows parsing a supported Trendmark into a TextWatermark, giving
@@ -28,9 +28,9 @@ import kotlin.jvm.JvmName
  * Sized TextWatermarks will create Trendmarks that encode the size of the Trendmark into the
  * watermark.
  *
- * Checked TextWatermarks will create Trendmarks that encode a CRC32 checksum into the watermark.
+ * CRC32 TextWatermarks will create Trendmarks that encode a CRC32 checksum into the watermark.
  *
- * Hashed TextWatermarks will create Trendmarks that encode a SHA3256 hash into the watermark.
+ * SHA3256 TextWatermarks will create Trendmarks that encode a SHA3256 hash into the watermark.
  *
  * Compressed TextWatermarks will compress the Text using a compression algorithm. This can be
  * useful when the watermark text is very long, but it might reduce the watermark robustness.
@@ -41,8 +41,8 @@ class TextWatermark private constructor(
     var text: String,
     private var compressed: Boolean = false,
     private var sized: Boolean = false,
-    private var checked: Boolean = false,
-    private var hashed: Boolean = false,
+    private var CRC32: Boolean = false,
+    private var SHA3256: Boolean = false,
 ) : TrendmarkBuilder {
     companion object {
         /**
@@ -77,42 +77,44 @@ class TextWatermark private constructor(
         fun sized(text: String): TextWatermark = TextWatermark(text, sized = true)
 
         /** Creates a TextWatermark from [text] with CRC32 checksum */
-        fun checked(text: String): TextWatermark = TextWatermark(text, checked = true)
+        @Suppress("ktlint:standard:function-naming")
+        fun CRC32(text: String): TextWatermark = TextWatermark(text, CRC32 = true)
 
         /** Creates a TextWatermark from [text] with SHA3256 hash */
-        fun hashed(text: String): TextWatermark = TextWatermark(text, hashed = true)
+        @Suppress("ktlint:standard:function-naming")
+        fun SHA3256(text: String): TextWatermark = TextWatermark(text, SHA3256 = true)
 
         /** Creates a TextWatermark from [text] with size information and compression */
-        fun compressedAndSized(text: String): TextWatermark =
+        fun compressedSized(text: String): TextWatermark =
             TextWatermark(text, compressed = true, sized = true)
 
-        /** Creates a TextWatermark from [text] with compression and checksum */
-        fun compressedAndChecked(text: String): TextWatermark =
-            TextWatermark(text, compressed = true, checked = true)
+        /** Creates a TextWatermark from [text] with compression and CRC32 checksum */
+        fun compressedCRC32(text: String): TextWatermark =
+            TextWatermark(text, compressed = true, CRC32 = true)
 
-        /** Creates a TextWatermark from [text] with compression and hash */
-        fun compressedAndHashed(text: String): TextWatermark =
-            TextWatermark(text, compressed = true, hashed = true)
+        /** Creates a TextWatermark from [text] with compression and SHA3256 hash */
+        fun compressedSHA3256(text: String): TextWatermark =
+            TextWatermark(text, compressed = true, SHA3256 = true)
 
-        /** Creates a TextWatermark from [text] with size information and checksum */
-        fun sizedAndChecked(text: String): TextWatermark =
-            TextWatermark(text, sized = true, checked = true)
+        /** Creates a TextWatermark from [text] with size information and CRC32 checksum */
+        fun sizedCRC32(text: String): TextWatermark =
+            TextWatermark(text, sized = true, CRC32 = true)
 
-        /** Creates a TextWatermark from [text] with size information and hash */
-        fun sizedAndHashed(text: String): TextWatermark =
-            TextWatermark(text, sized = true, hashed = true)
+        /** Creates a TextWatermark from [text] with size information and SHA3256 hash */
+        fun sizedSHA3256(text: String): TextWatermark =
+            TextWatermark(text, sized = true, SHA3256 = true)
 
-        /** Creates a TextWatermark from [text] with compression, size information and checksum */
-        fun compressedSizedChecked(text: String): TextWatermark =
-            TextWatermark(text, compressed = true, sized = true, checked = true)
+        /** Creates a TextWatermark from [text] with compression, size information and CRC32 checksum */
+        fun compressedSizedCRC32(text: String): TextWatermark =
+            TextWatermark(text, compressed = true, sized = true, CRC32 = true)
 
-        /** Creates a TextWatermark from [text] with compression, size information and hash */
-        fun compressedSizedHashed(text: String): TextWatermark =
-            TextWatermark(text, compressed = true, sized = true, hashed = true)
+        /** Creates a TextWatermark from [text] with compression, size information and SHA3256 hash */
+        fun compressedSizedSHA3256(text: String): TextWatermark =
+            TextWatermark(text, compressed = true, sized = true, SHA3256 = true)
 
         /**
          * Creates a TextWatermark from [trendmark].
-         * Sets sized, compressed, checked and hashed depending on the variant of [trendmark].
+         * Sets sized, compressed, CRC32 and SHA3256 depending on the variant of [trendmark].
          *
          * When [errorOnInvalidUTF8] is true: invalid bytes sequences cause an error.
          *                           is false: invalid bytes sequences are replace with the char �.
@@ -145,18 +147,18 @@ class TextWatermark private constructor(
                     is CompressedSizedTrendmark ->
                         TextWatermark(text, compressed = true, sized = true)
 
-                    is CRC32Trendmark -> TextWatermark(text, checked = true)
-                    is SizedCRC32Trendmark -> TextWatermark(text, sized = true, checked = true)
+                    is CRC32Trendmark -> TextWatermark(text, CRC32 = true)
+                    is SizedCRC32Trendmark -> TextWatermark(text, sized = true, CRC32 = true)
                     is CompressedCRC32Trendmark ->
-                        TextWatermark(text, compressed = true, checked = true)
+                        TextWatermark(text, compressed = true, CRC32 = true)
                     is CompressedSizedCRC32Trendmark ->
-                        TextWatermark(text, compressed = true, sized = true, checked = true)
-                    is SHA3256Trendmark -> TextWatermark(text, hashed = true)
-                    is SizedSHA3256Trendmark -> TextWatermark(text, sized = true, hashed = true)
+                        TextWatermark(text, compressed = true, sized = true, CRC32 = true)
+                    is SHA3256Trendmark -> TextWatermark(text, SHA3256 = true)
+                    is SizedSHA3256Trendmark -> TextWatermark(text, sized = true, SHA3256 = true)
                     is CompressedSHA3256Trendmark ->
-                        TextWatermark(text, compressed = true, hashed = true)
+                        TextWatermark(text, compressed = true, SHA3256 = true)
                     is CompressedSizedSHA3256Trendmark ->
-                        TextWatermark(text, compressed = true, sized = true, hashed = true)
+                        TextWatermark(text, compressed = true, sized = true, SHA3256 = true)
                     else -> {
                         status.addEvent(UnsupportedTrendmarkError(trendmark.getSource()))
                         return status.into<_>()
@@ -183,21 +185,23 @@ class TextWatermark private constructor(
     /** true if size information is added to the Trendmark */
     fun isSized(): Boolean = sized
 
-    /** sets checked to [active] */
-    fun checked(active: Boolean = true) {
-        checked = active
+    /** sets CRC32 to [active] */
+    @Suppress("ktlint:standard:function-naming")
+    fun CRC32(active: Boolean = true) {
+        CRC32 = active
     }
 
     /** true if checksum information is added to the Trendmark */
-    fun isChecked(): Boolean = checked
+    fun isCRC32(): Boolean = CRC32
 
-    /** sets hashed to [active] */
-    fun hashed(active: Boolean = true) {
-        hashed = active
+    /** sets SHA3256 to [active] */
+    @Suppress("ktlint:standard:function-naming")
+    fun SHA3256(active: Boolean = true) {
+        SHA3256 = active
     }
 
     /** true if hash information is added to the Trendmark */
-    fun isHashed(): Boolean = hashed
+    fun isSHA3256(): Boolean = SHA3256
 
     /**
      * Generates a Trendmark with [text] as content.
@@ -205,27 +209,27 @@ class TextWatermark private constructor(
      * The used variant of Trendmark depends on:
      *  - [compressed]
      *  - [sized]
-     *  - [checked]
-     *  - [hashed].
+     *  - [CRC32]
+     *  - [SHA3256].
      */
     override fun finish(): Trendmark {
         val content = text.encodeToByteArray().asList()
 
-        return if (compressed && sized && hashed) {
+        return if (compressed && sized && SHA3256) {
             CompressedSizedSHA3256Trendmark.new(content)
-        } else if (compressed && hashed) {
+        } else if (compressed && SHA3256) {
             CompressedSHA3256Trendmark.new(content)
-        } else if (sized && hashed) {
+        } else if (sized && SHA3256) {
             SizedSHA3256Trendmark.new(content)
-        } else if (hashed) {
+        } else if (SHA3256) {
             SHA3256Trendmark.new(content)
-        } else if (compressed && sized && checked) {
+        } else if (compressed && sized && CRC32) {
             CompressedSizedCRC32Trendmark.new(content)
-        } else if (compressed && checked) {
+        } else if (compressed && CRC32) {
             CompressedCRC32Trendmark.new(content)
-        } else if (sized && checked) {
+        } else if (sized && CRC32) {
             SizedCRC32Trendmark.new(content)
-        } else if (checked) {
+        } else if (CRC32) {
             CRC32Trendmark.new(content)
         } else if (compressed && sized) {
             CompressedSizedTrendmark.new(content)
@@ -240,24 +244,24 @@ class TextWatermark private constructor(
 
     /** Contains the used Trendmark variant followed by [text] */
     override fun toString(): String {
-        return if (compressed && sized && hashed) {
-            "CompressedSizedHashedTextWatermark: '$text'"
-        } else if (compressed && hashed) {
-            "CompressedAndHashedTextWatermark: '$text'"
-        } else if (sized && hashed) {
-            "SizedAndHashedTextWatermark: '$text'"
-        } else if (hashed) {
-            "HashedTextWatermark: '$text'"
-        } else if (compressed && sized && checked) {
-            "CompressedSizedCheckedTextWatermark: '$text'"
-        } else if (compressed && checked) {
-            "CompressedAndCheckedTextWatermark: '$text'"
-        } else if (sized && checked) {
-            "SizedAndCheckedTextWatermark: '$text'"
-        } else if (checked) {
-            "CheckedTextWatermark: '$text'"
+        return if (compressed && sized && SHA3256) {
+            "CompressedSizedSHA3256TextWatermark: '$text'"
+        } else if (compressed && SHA3256) {
+            "CompressedSHA3256TextWatermark: '$text'"
+        } else if (sized && SHA3256) {
+            "SizedSHA3256TextWatermark: '$text'"
+        } else if (SHA3256) {
+            "SHA3256TextWatermark: '$text'"
+        } else if (compressed && sized && CRC32) {
+            "CompressedSizedCRC32TextWatermark: '$text'"
+        } else if (compressed && CRC32) {
+            "CompressedCRC32TextWatermark: '$text'"
+        } else if (sized && CRC32) {
+            "SizedCRC32TextWatermark: '$text'"
+        } else if (CRC32) {
+            "CRC32TextWatermark: '$text'"
         } else if (compressed && sized) {
-            "CompressedAndSizedTextWatermark: '$text'"
+            "CompressedSizedTextWatermark: '$text'"
         } else if (compressed) {
             "CompressedTextWatermark: '$text'"
         } else if (sized) {
@@ -271,7 +275,7 @@ class TextWatermark private constructor(
     override fun equals(other: Any?): Boolean {
         if (other !is TextWatermark) return false
         return text == other.text && compressed == other.compressed && sized == other.sized &&
-            checked == other.checked && hashed == other.hashed
+            CRC32 == other.CRC32 && SHA3256 == other.SHA3256
     }
 
     class DecodeToStringError(val reason: String) : Event.Error("TextWatermark.fromTrendmark") {

--- a/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
@@ -617,10 +617,10 @@ class RawTrendmark(content: List<Byte>) : Trendmark(content) {
         ): List<Byte> = listOf(tag.toByte()) + content
     }
 
-    /** Constant function that returns the tag used to encode this Trendmark class */
+    /** Constant function that returns the name of the specific Trendmark */
     override fun getSource(): String = SOURCE
 
-    /** Constant function that returns the name of the specific Trendmark */
+    /** Constant function that returns the tag used to encode this Trendmark class */
     override fun getTag(): UByte = TYPE_TAG
 
     /** Returns the decoded information stored in the Trendmark */

--- a/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
@@ -1087,7 +1087,7 @@ class CompressedCRC32Trendmark(content: List<Byte>) :
 
 @JsExport
 class CompressedSizedCRC32Trendmark(content: List<Byte>) :
-    Trendmark(content), Trendmark.Sized, Trendmark.Checksum {
+    Trendmark(content), Trendmark.Sized, Trendmark.Checksum, Trendmark.Compressed {
     companion object {
         const val SOURCE = "Trendmark.CompressedSizedCRC32Trendmark"
         const val TYPE_TAG: UByte = 251u

--- a/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt
@@ -666,10 +666,10 @@ class SizedTrendmark(content: List<Byte>) : Trendmark(content), Trendmark.Sized 
         }
     }
 
-    /** Constant function that returns the tag used to encode this Trendmark class */
+    /** Constant function that returns the name of the specific Trendmark */
     override fun getSource(): String = SOURCE
 
-    /** Constant function that returns the name of the specific Trendmark */
+    /** Constant function that returns the tag used to encode this Trendmark class */
     override fun getTag(): UByte = TYPE_TAG
 
     /** Returns the decoded information stored in the Trendmark */

--- a/watermarker/src/commonTest/kotlin/unitTest/watermarks/TextWatermarkTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/watermarks/TextWatermarkTest.kt
@@ -43,8 +43,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
@@ -64,8 +64,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
@@ -85,8 +85,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
@@ -108,8 +108,8 @@ class TextWatermarkTest {
         assertEquals(customText, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(customTextBytes, content.value)
@@ -131,8 +131,8 @@ class TextWatermarkTest {
         assertEquals(customText, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(customTextBytes, content.value)
@@ -152,20 +152,21 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
     }
 
     @Test
-    fun checked_loremIpsum_success() {
+    @Suppress("ktlint:standard:function-naming")
+    fun CRC32_loremIpsum_success() {
         // Arrange
         val expectedTrendmark = CRC32Trendmark.new(textBytes)
 
         // Act
-        val textWatermark = TextWatermark.checked(text)
+        val textWatermark = TextWatermark.CRC32(text)
         val trendmark = textWatermark.finish()
         val content = trendmark.getContent()
 
@@ -173,20 +174,21 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertTrue(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertTrue(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
     }
 
     @Test
-    fun hashed_loremIpsum_success() {
+    @Suppress("ktlint:standard:function-naming")
+    fun SHA3256_loremIpsum_success() {
         // Arrange
         val expectedTrendmark = SHA3256Trendmark.new(textBytes)
 
         // Act
-        val textWatermark = TextWatermark.hashed(text)
+        val textWatermark = TextWatermark.SHA3256(text)
         val trendmark = textWatermark.finish()
         val content = trendmark.getContent()
 
@@ -194,20 +196,20 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertTrue(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertTrue(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
     }
 
     @Test
-    fun compressedAndSized_loremIpsum_success() {
+    fun compressedSized_loremIpsum_success() {
         // Arrange
         val expectedTrendmark = CompressedSizedTrendmark.new(textBytes)
 
         // Act
-        val textWatermark = TextWatermark.compressedAndSized(text)
+        val textWatermark = TextWatermark.compressedSized(text)
         val trendmark = textWatermark.finish()
         val content = trendmark.getContent()
 
@@ -215,20 +217,20 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
     }
 
     @Test
-    fun compressedAndChecked_loremIpsum_success() {
+    fun compressedCRC32_loremIpsum_success() {
         // Arrange
         val expectedTrendmark = CompressedCRC32Trendmark.new(textBytes)
 
         // Act
-        val textWatermark = TextWatermark.compressedAndChecked(text)
+        val textWatermark = TextWatermark.compressedCRC32(text)
         val trendmark = textWatermark.finish()
         val content = trendmark.getContent()
 
@@ -236,20 +238,20 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
-        assertTrue(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertTrue(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
     }
 
     @Test
-    fun compressedAndHashed_loremIpsum_success() {
+    fun compressedSHA3256_loremIpsum_success() {
         // Arrange
         val expectedTrendmark = CompressedSHA3256Trendmark.new(textBytes)
 
         // Act
-        val textWatermark = TextWatermark.compressedAndHashed(text)
+        val textWatermark = TextWatermark.compressedSHA3256(text)
         val trendmark = textWatermark.finish()
         val content = trendmark.getContent()
 
@@ -257,20 +259,20 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertTrue(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertTrue(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
     }
 
     @Test
-    fun sizedAndChecked_loremIpsum_success() {
+    fun sizedCRC32_loremIpsum_success() {
         // Arrange
         val expectedTrendmark = SizedCRC32Trendmark.new(textBytes)
 
         // Act
-        val textWatermark = TextWatermark.sizedAndChecked(text)
+        val textWatermark = TextWatermark.sizedCRC32(text)
         val trendmark = textWatermark.finish()
         val content = trendmark.getContent()
 
@@ -278,20 +280,20 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertTrue(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertTrue(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
     }
 
     @Test
-    fun sizedAndHashed_loremIpsum_success() {
+    fun sizedSHA3256_loremIpsum_success() {
         // Arrange
         val expectedTrendmark = SizedSHA3256Trendmark.new(textBytes)
 
         // Act
-        val textWatermark = TextWatermark.sizedAndHashed(text)
+        val textWatermark = TextWatermark.sizedSHA3256(text)
         val trendmark = textWatermark.finish()
         val content = trendmark.getContent()
 
@@ -299,20 +301,20 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertTrue(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertTrue(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
     }
 
     @Test
-    fun compressedSizedChecked_loremIpsum_success() {
+    fun compressedSizedCRC32_loremIpsum_success() {
         // Arrange
         val expectedTrendmark = CompressedSizedCRC32Trendmark.new(textBytes)
 
         // Act
-        val textWatermark = TextWatermark.compressedSizedChecked(text)
+        val textWatermark = TextWatermark.compressedSizedCRC32(text)
         val trendmark = textWatermark.finish()
         val content = trendmark.getContent()
 
@@ -320,20 +322,20 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
-        assertTrue(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertTrue(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
     }
 
     @Test
-    fun compressedSizedHashed_loremIpsum_success() {
+    fun compressedSizedSHA3256_loremIpsum_success() {
         // Arrange
         val expectedTrendmark = CompressedSizedSHA3256Trendmark.new(textBytes)
 
         // Act
-        val textWatermark = TextWatermark.compressedSizedHashed(text)
+        val textWatermark = TextWatermark.compressedSizedSHA3256(text)
         val trendmark = textWatermark.finish()
         val content = trendmark.getContent()
 
@@ -341,8 +343,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertTrue(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertTrue(textWatermark.isSHA3256())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
@@ -363,8 +365,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -384,8 +386,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -405,8 +407,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -426,8 +428,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertTrue(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertTrue(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -447,8 +449,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertTrue(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertTrue(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -468,8 +470,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
-        assertTrue(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertTrue(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -489,8 +491,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
-        assertTrue(textWatermark.isChecked())
-        assertFalse(textWatermark.isHashed())
+        assertTrue(textWatermark.isCRC32())
+        assertFalse(textWatermark.isSHA3256())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -510,8 +512,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertTrue(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertTrue(textWatermark.isSHA3256())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -531,8 +533,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertTrue(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertTrue(textWatermark.isSHA3256())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -552,8 +554,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertTrue(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertTrue(textWatermark.isSHA3256())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -573,8 +575,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
-        assertFalse(textWatermark.isChecked())
-        assertTrue(textWatermark.isHashed())
+        assertFalse(textWatermark.isCRC32())
+        assertTrue(textWatermark.isSHA3256())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -604,26 +606,28 @@ class TextWatermarkTest {
     }
 
     @Test
-    fun checked_true_true() {
+    @Suppress("ktlint:standard:function-naming")
+    fun CRC32_true_true() {
         // Arrange
-        val textWatermark = TextWatermark.checked(text)
+        val textWatermark = TextWatermark.CRC32(text)
 
         // Act
-        textWatermark.checked()
+        textWatermark.CRC32()
 
         // Assert
-        assertTrue(textWatermark.isChecked())
+        assertTrue(textWatermark.isCRC32())
     }
 
     @Test
-    fun hashed_true_true() {
+    @Suppress("ktlint:standard:function-naming")
+    fun SHA3256_true_true() {
         // Arrange
-        val textWatermark = TextWatermark.hashed(text)
+        val textWatermark = TextWatermark.SHA3256(text)
 
         // Act
-        textWatermark.hashed()
+        textWatermark.SHA3256()
 
         // Assert
-        assertTrue(textWatermark.isHashed())
+        assertTrue(textWatermark.isSHA3256())
     }
 }

--- a/watermarker/src/commonTest/kotlin/unitTest/watermarks/TextWatermarkTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/watermarks/TextWatermarkTest.kt
@@ -23,7 +23,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class TextWatermarkTest {
@@ -44,6 +43,29 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
+        assertEquals(expectedTrendmark, trendmark)
+        assertTrue(content.isSuccess)
+        assertEquals(textBytes, content.value)
+    }
+
+    @Test
+    fun raw_loremIpsum_success() {
+        // Arrange
+        val expectedTrendmark = RawTrendmark.new(textBytes)
+
+        // Act
+        val textWatermark = TextWatermark.raw(text)
+        val trendmark = textWatermark.finish()
+        val content = trendmark.getContent()
+
+        // Assert
+        assertEquals(text, textWatermark.text)
+        assertFalse(textWatermark.isSized())
+        assertFalse(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
@@ -63,6 +85,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
@@ -84,6 +108,8 @@ class TextWatermarkTest {
         assertEquals(customText, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(customTextBytes, content.value)
@@ -105,6 +131,8 @@ class TextWatermarkTest {
         assertEquals(customText, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(customTextBytes, content.value)
@@ -124,6 +152,50 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
+        assertEquals(expectedTrendmark, trendmark)
+        assertTrue(content.isSuccess)
+        assertEquals(textBytes, content.value)
+    }
+
+    @Test
+    fun checked_loremIpsum_success() {
+        // Arrange
+        val expectedTrendmark = CRC32Trendmark.new(textBytes)
+
+        // Act
+        val textWatermark = TextWatermark.checked(text)
+        val trendmark = textWatermark.finish()
+        val content = trendmark.getContent()
+
+        // Assert
+        assertEquals(text, textWatermark.text)
+        assertFalse(textWatermark.isSized())
+        assertFalse(textWatermark.isCompressed())
+        assertTrue(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
+        assertEquals(expectedTrendmark, trendmark)
+        assertTrue(content.isSuccess)
+        assertEquals(textBytes, content.value)
+    }
+
+    @Test
+    fun hashed_loremIpsum_success() {
+        // Arrange
+        val expectedTrendmark = SHA3256Trendmark.new(textBytes)
+
+        // Act
+        val textWatermark = TextWatermark.hashed(text)
+        val trendmark = textWatermark.finish()
+        val content = trendmark.getContent()
+
+        // Assert
+        assertEquals(text, textWatermark.text)
+        assertFalse(textWatermark.isSized())
+        assertFalse(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertTrue(textWatermark.isHashed())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
@@ -143,6 +215,134 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
+        assertEquals(expectedTrendmark, trendmark)
+        assertTrue(content.isSuccess)
+        assertEquals(textBytes, content.value)
+    }
+
+    @Test
+    fun compressedAndChecked_loremIpsum_success() {
+        // Arrange
+        val expectedTrendmark = CompressedCRC32Trendmark.new(textBytes)
+
+        // Act
+        val textWatermark = TextWatermark.compressedAndChecked(text)
+        val trendmark = textWatermark.finish()
+        val content = trendmark.getContent()
+
+        // Assert
+        assertEquals(text, textWatermark.text)
+        assertFalse(textWatermark.isSized())
+        assertTrue(textWatermark.isCompressed())
+        assertTrue(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
+        assertEquals(expectedTrendmark, trendmark)
+        assertTrue(content.isSuccess)
+        assertEquals(textBytes, content.value)
+    }
+
+    @Test
+    fun compressedAndHashed_loremIpsum_success() {
+        // Arrange
+        val expectedTrendmark = CompressedSHA3256Trendmark.new(textBytes)
+
+        // Act
+        val textWatermark = TextWatermark.compressedAndHashed(text)
+        val trendmark = textWatermark.finish()
+        val content = trendmark.getContent()
+
+        // Assert
+        assertEquals(text, textWatermark.text)
+        assertFalse(textWatermark.isSized())
+        assertTrue(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertTrue(textWatermark.isHashed())
+        assertEquals(expectedTrendmark, trendmark)
+        assertTrue(content.isSuccess)
+        assertEquals(textBytes, content.value)
+    }
+
+    @Test
+    fun sizedAndChecked_loremIpsum_success() {
+        // Arrange
+        val expectedTrendmark = SizedCRC32Trendmark.new(textBytes)
+
+        // Act
+        val textWatermark = TextWatermark.sizedAndChecked(text)
+        val trendmark = textWatermark.finish()
+        val content = trendmark.getContent()
+
+        // Assert
+        assertEquals(text, textWatermark.text)
+        assertTrue(textWatermark.isSized())
+        assertFalse(textWatermark.isCompressed())
+        assertTrue(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
+        assertEquals(expectedTrendmark, trendmark)
+        assertTrue(content.isSuccess)
+        assertEquals(textBytes, content.value)
+    }
+
+    @Test
+    fun sizedAndHashed_loremIpsum_success() {
+        // Arrange
+        val expectedTrendmark = SizedSHA3256Trendmark.new(textBytes)
+
+        // Act
+        val textWatermark = TextWatermark.sizedAndHashed(text)
+        val trendmark = textWatermark.finish()
+        val content = trendmark.getContent()
+
+        // Assert
+        assertEquals(text, textWatermark.text)
+        assertTrue(textWatermark.isSized())
+        assertFalse(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertTrue(textWatermark.isHashed())
+        assertEquals(expectedTrendmark, trendmark)
+        assertTrue(content.isSuccess)
+        assertEquals(textBytes, content.value)
+    }
+
+    @Test
+    fun compressedSizedChecked_loremIpsum_success() {
+        // Arrange
+        val expectedTrendmark = CompressedSizedCRC32Trendmark.new(textBytes)
+
+        // Act
+        val textWatermark = TextWatermark.compressedSizedChecked(text)
+        val trendmark = textWatermark.finish()
+        val content = trendmark.getContent()
+
+        // Assert
+        assertEquals(text, textWatermark.text)
+        assertTrue(textWatermark.isSized())
+        assertTrue(textWatermark.isCompressed())
+        assertTrue(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
+        assertEquals(expectedTrendmark, trendmark)
+        assertTrue(content.isSuccess)
+        assertEquals(textBytes, content.value)
+    }
+
+    @Test
+    fun compressedSizedHashed_loremIpsum_success() {
+        // Arrange
+        val expectedTrendmark = CompressedSizedSHA3256Trendmark.new(textBytes)
+
+        // Act
+        val textWatermark = TextWatermark.compressedSizedHashed(text)
+        val trendmark = textWatermark.finish()
+        val content = trendmark.getContent()
+
+        // Assert
+        assertEquals(text, textWatermark.text)
+        assertTrue(textWatermark.isSized())
+        assertTrue(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertTrue(textWatermark.isHashed())
         assertEquals(expectedTrendmark, trendmark)
         assertTrue(content.isSuccess)
         assertEquals(textBytes, content.value)
@@ -163,6 +363,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertFalse(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -182,6 +384,8 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertFalse(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
@@ -201,140 +405,184 @@ class TextWatermarkTest {
         assertEquals(text, textWatermark.text)
         assertTrue(textWatermark.isSized())
         assertTrue(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
         assertNotNull(trendmark)
         assertEquals(initialTrendmark, trendmark)
     }
 
     @Test
-    fun fromTrendmark_CRC32Trendmark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_CRC32Trendmark_success() {
         // Arrange
-        val trendmark = CRC32Trendmark.new(textBytes)
-        val expectedStatus = TextWatermark.UnsupportedTrendmarkError(CRC32Trendmark.SOURCE).into()
+        val initialTrendmark = CRC32Trendmark.new(textBytes)
 
         // Act
-        val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
+        val textWatermarkResult = TextWatermark.fromTrendmark(initialTrendmark)
+        val trendmark = textWatermarkResult.value?.finish()
 
         // Assert
-        assertTrue(textWatermarkResult.isError)
-        assertEquals(expectedStatus.getMessage(), textWatermarkResult.status.getMessage())
-        assertNull(textWatermarkResult.value)
+        assertTrue(textWatermarkResult.isSuccess)
+        val textWatermark = textWatermarkResult.value!!
+        assertEquals(text, textWatermark.text)
+        assertFalse(textWatermark.isSized())
+        assertFalse(textWatermark.isCompressed())
+        assertTrue(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
+        assertNotNull(trendmark)
+        assertEquals(initialTrendmark, trendmark)
     }
 
     @Test
-    fun fromTrendmark_SizedCRC32Trendmark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_SizedCRC32Trendmark_success() {
         // Arrange
-        val trendmark = SizedCRC32Trendmark.new(textBytes)
-        val expectedStatus =
-            TextWatermark.UnsupportedTrendmarkError(SizedCRC32Trendmark.SOURCE).into()
+        val initialTrendmark = SizedCRC32Trendmark.new(textBytes)
 
         // Act
-        val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
+        val textWatermarkResult = TextWatermark.fromTrendmark(initialTrendmark)
+        val trendmark = textWatermarkResult.value?.finish()
 
         // Assert
-        assertTrue(textWatermarkResult.isError)
-        assertEquals(expectedStatus.getMessage(), textWatermarkResult.status.getMessage())
-        assertNull(textWatermarkResult.value)
+        assertTrue(textWatermarkResult.isSuccess)
+        val textWatermark = textWatermarkResult.value!!
+        assertEquals(text, textWatermark.text)
+        assertTrue(textWatermark.isSized())
+        assertFalse(textWatermark.isCompressed())
+        assertTrue(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
+        assertNotNull(trendmark)
+        assertEquals(initialTrendmark, trendmark)
     }
 
     @Test
-    fun fromTrendmark_CompressedCRC32Trendmark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_CompressedCRC32Trendmark_success() {
         // Arrange
-        val trendmark = CompressedCRC32Trendmark.new(textBytes)
-        val expectedStatus =
-            TextWatermark.UnsupportedTrendmarkError(CompressedCRC32Trendmark.SOURCE).into()
+        val initialTrendmark = CompressedCRC32Trendmark.new(textBytes)
 
         // Act
-        val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
+        val textWatermarkResult = TextWatermark.fromTrendmark(initialTrendmark)
+        val trendmark = textWatermarkResult.value?.finish()
 
         // Assert
-        assertTrue(textWatermarkResult.isError)
-        assertEquals(expectedStatus.getMessage(), textWatermarkResult.status.getMessage())
-        assertNull(textWatermarkResult.value)
+        assertTrue(textWatermarkResult.isSuccess)
+        val textWatermark = textWatermarkResult.value!!
+        assertEquals(text, textWatermark.text)
+        assertFalse(textWatermark.isSized())
+        assertTrue(textWatermark.isCompressed())
+        assertTrue(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
+        assertNotNull(trendmark)
+        assertEquals(initialTrendmark, trendmark)
     }
 
     @Test
-    fun fromTrendmark_CompressedSizedCRC32Trendmark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_CompressedSizedCRC32Trendmark_success() {
         // Arrange
-        val trendmark = CompressedSizedCRC32Trendmark.new(textBytes)
-        val expectedStatus =
-            TextWatermark.UnsupportedTrendmarkError(CompressedSizedCRC32Trendmark.SOURCE).into()
+        val initialTrendmark = CompressedSizedCRC32Trendmark.new(textBytes)
 
         // Act
-        val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
+        val textWatermarkResult = TextWatermark.fromTrendmark(initialTrendmark)
+        val trendmark = textWatermarkResult.value?.finish()
 
         // Assert
-        assertTrue(textWatermarkResult.isError)
-        assertEquals(expectedStatus.getMessage(), textWatermarkResult.status.getMessage())
-        assertNull(textWatermarkResult.value)
+        assertTrue(textWatermarkResult.isSuccess)
+        val textWatermark = textWatermarkResult.value!!
+        assertEquals(text, textWatermark.text)
+        assertTrue(textWatermark.isSized())
+        assertTrue(textWatermark.isCompressed())
+        assertTrue(textWatermark.isChecked())
+        assertFalse(textWatermark.isHashed())
+        assertNotNull(trendmark)
+        assertEquals(initialTrendmark, trendmark)
     }
 
     @Test
-    fun fromTrendmark_SHA3256Trendmark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_SHA3256Trendmark_success() {
         // Arrange
-        val trendmark = SHA3256Trendmark.new(textBytes)
-        val expectedStatus = TextWatermark.UnsupportedTrendmarkError(SHA3256Trendmark.SOURCE).into()
+        val initialTrendmark = SHA3256Trendmark.new(textBytes)
 
         // Act
-        val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
+        val textWatermarkResult = TextWatermark.fromTrendmark(initialTrendmark)
+        val trendmark = textWatermarkResult.value?.finish()
 
         // Assert
-        assertTrue(textWatermarkResult.isError)
-        assertEquals(expectedStatus.getMessage(), textWatermarkResult.status.getMessage())
-        assertNull(textWatermarkResult.value)
+        assertTrue(textWatermarkResult.isSuccess)
+        val textWatermark = textWatermarkResult.value!!
+        assertEquals(text, textWatermark.text)
+        assertFalse(textWatermark.isSized())
+        assertFalse(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertTrue(textWatermark.isHashed())
+        assertNotNull(trendmark)
+        assertEquals(initialTrendmark, trendmark)
     }
 
     @Test
-    fun fromTrendmark_SizedSHA3256Trendmark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_SizedSHA3256Trendmark_success() {
         // Arrange
-        val trendmark = SizedSHA3256Trendmark.new(textBytes)
-        val expectedStatus =
-            TextWatermark.UnsupportedTrendmarkError(SizedSHA3256Trendmark.SOURCE).into()
+        val initialTrendmark = SizedSHA3256Trendmark.new(textBytes)
 
         // Act
-        val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
+        val textWatermarkResult = TextWatermark.fromTrendmark(initialTrendmark)
+        val trendmark = textWatermarkResult.value?.finish()
 
         // Assert
-        assertTrue(textWatermarkResult.isError)
-        assertEquals(expectedStatus.getMessage(), textWatermarkResult.status.getMessage())
-        assertNull(textWatermarkResult.value)
+        assertTrue(textWatermarkResult.isSuccess)
+        val textWatermark = textWatermarkResult.value!!
+        assertEquals(text, textWatermark.text)
+        assertTrue(textWatermark.isSized())
+        assertFalse(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertTrue(textWatermark.isHashed())
+        assertNotNull(trendmark)
+        assertEquals(initialTrendmark, trendmark)
     }
 
     @Test
-    fun fromTrendmark_CompressedSHA3256Trendmark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_CompressedSHA3256Trendmark_success() {
         // Arrange
-        val trendmark = CompressedSHA3256Trendmark.new(textBytes)
-        val expectedStatus =
-            TextWatermark.UnsupportedTrendmarkError(CompressedSHA3256Trendmark.SOURCE).into()
+        val initialTrendmark = CompressedSHA3256Trendmark.new(textBytes)
 
         // Act
-        val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
+        val textWatermarkResult = TextWatermark.fromTrendmark(initialTrendmark)
+        val trendmark = textWatermarkResult.value?.finish()
 
         // Assert
-        assertTrue(textWatermarkResult.isError)
-        assertEquals(expectedStatus.getMessage(), textWatermarkResult.status.getMessage())
-        assertNull(textWatermarkResult.value)
+        assertTrue(textWatermarkResult.isSuccess)
+        val textWatermark = textWatermarkResult.value!!
+        assertEquals(text, textWatermark.text)
+        assertFalse(textWatermark.isSized())
+        assertTrue(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertTrue(textWatermark.isHashed())
+        assertNotNull(trendmark)
+        assertEquals(initialTrendmark, trendmark)
     }
 
     @Test
-    fun fromTrendmark_CompressedSizedSHA3256Trendmark_UnsupportedTrendmarkError() {
+    fun fromTrendmark_CompressedSizedSHA3256Trendmark_success() {
         // Arrange
-        val trendmark = CompressedSizedSHA3256Trendmark.new(textBytes)
-        val expectedStatus =
-            TextWatermark.UnsupportedTrendmarkError(CompressedSizedSHA3256Trendmark.SOURCE).into()
+        val initialTrendmark = CompressedSizedSHA3256Trendmark.new(textBytes)
 
         // Act
-        val textWatermarkResult = TextWatermark.fromTrendmark(trendmark)
+        val textWatermarkResult = TextWatermark.fromTrendmark(initialTrendmark)
+        val trendmark = textWatermarkResult.value?.finish()
 
         // Assert
-        assertTrue(textWatermarkResult.isError)
-        assertEquals(expectedStatus.getMessage(), textWatermarkResult.status.getMessage())
-        assertNull(textWatermarkResult.value)
+        assertTrue(textWatermarkResult.isSuccess)
+        val textWatermark = textWatermarkResult.value!!
+        assertEquals(text, textWatermark.text)
+        assertTrue(textWatermark.isSized())
+        assertTrue(textWatermark.isCompressed())
+        assertFalse(textWatermark.isChecked())
+        assertTrue(textWatermark.isHashed())
+        assertNotNull(trendmark)
+        assertEquals(initialTrendmark, trendmark)
     }
 
     @Test
     fun compressed_true_true() {
         // Arrange
-        val textWatermark = TextWatermark.new(text)
+        val textWatermark = TextWatermark.compressed(text)
 
         // Act
         textWatermark.compressed()
@@ -353,5 +601,29 @@ class TextWatermarkTest {
 
         // Assert
         assertTrue(textWatermark.isSized())
+    }
+
+    @Test
+    fun checked_true_true() {
+        // Arrange
+        val textWatermark = TextWatermark.checked(text)
+
+        // Act
+        textWatermark.checked()
+
+        // Assert
+        assertTrue(textWatermark.isChecked())
+    }
+
+    @Test
+    fun hashed_true_true() {
+        // Arrange
+        val textWatermark = TextWatermark.hashed(text)
+
+        // Act
+        textWatermark.hashed()
+
+        // Assert
+        assertTrue(textWatermark.isHashed())
     }
 }


### PR DESCRIPTION
## Description
Add support for all current non-custom Trendmarks in TextWatermark, update TextWatermarkTest accordingly, as well as the following minor fixes to the Trendmark file:
- update comments for getSource and getTag functions as they were switched
- add missing implementation of Trendmark.Compressed in CompressedSizedCRC32Trendmark class

## Linked Issue(s)
Fixes #128 , #107 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
