### PR TITLE
fix(watermarker): update bad java function names

### DIFF
--- a/watermarker/src/commonMain/kotlin/returnTypes/Result.kt
+++ b/watermarker/src/commonMain/kotlin/returnTypes/Result.kt
@@ -54,7 +54,7 @@ class Result<T> constructor(
 
     /**
      * Returns the message representing the Result containing the messages of all events.
-     * It omits the type of each event and only add the message. Use toString if the event type
+     * It omits the type of each event and only adds the message. Use toString if the event type
      * should be added as well.
      */
     fun getMessage() = status.getMessage()

--- a/watermarker/src/commonMain/kotlin/returnTypes/Result.kt
+++ b/watermarker/src/commonMain/kotlin/returnTypes/Result.kt
@@ -9,6 +9,7 @@ package de.fraunhofer.isst.trend.watermarker.returnTypes
 
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlin.jvm.JvmName
 
 /**
  * This class represents the result of a function that returns a value but also can fail or produce
@@ -22,6 +23,7 @@ class Result<T> constructor(
     val value: T? = null,
 ) {
     /** Checks if the result contains a value */
+    @get:JvmName("hasValue")
     val hasValue get() = value != null
 
     /** Creates a new Result<T> from [status] and [value] */

--- a/watermarker/src/commonMain/kotlin/returnTypes/Status.kt
+++ b/watermarker/src/commonMain/kotlin/returnTypes/Status.kt
@@ -188,7 +188,7 @@ class Status(event: Event? = null) {
 
     /**
      * Returns the message representing the Status containing the messages of all events.
-     * It omits the type of each event and only add the message. Use toString if the event type
+     * It omits the type of each event and only adds the message. Use toString if the event type
      * should be added as well.
      */
     fun getMessage(): String {

--- a/watermarker/src/commonMain/kotlin/returnTypes/Status.kt
+++ b/watermarker/src/commonMain/kotlin/returnTypes/Status.kt
@@ -8,6 +8,7 @@ package de.fraunhofer.isst.trend.watermarker.returnTypes
 
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlin.jvm.JvmName
 
 /**
  * An Event represents different kinds of events that can occur during the execution of a function.
@@ -28,6 +29,7 @@ sealed class Event(
     /** Returns a String explaining the event */
     abstract fun getMessage(): String?
 
+    @get:JvmName("hasCustomMessage")
     val hasCustomMessage: Boolean get() = getMessage() != null
 
     /** Returns a String explaining the event: "Type (source): message" */
@@ -121,6 +123,7 @@ class Status(event: Event? = null) {
     val isError: Boolean get() = type == Type.ERROR
 
     /** Check if any event contains a custom message */
+    @get:JvmName("hasCustomMessage")
     val hasCustomMessage: Boolean get() = eventList.any { it.hasCustomMessage }
 
     /**


### PR DESCRIPTION
## Description
Update with a JvmName annotation all Kotlin members that return a boolean and start with "has..." since the prefix "is..." is unaffected (see [Kotlin Docs](https://kotlinlang.org/docs/java-to-kotlin-interop.html) under "Properties")

## Linked Issue(s)
Fixes #85 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
