### PR TITLE
fix(watermarker): fix single watermark insertion and extraction

### DIFF
--- a/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
@@ -330,7 +330,9 @@ class TextWatermarker(
         val separatedWatermark = getSeparatedWatermark(watermark)
         return if (separatorStrategy is SeparatorStrategy.StartEndSeparatorChars) {
             separatedWatermark.count()
-        }else separatedWatermark.count()+1
+        } else {
+            separatedWatermark.count() + 1
+        }
     }
 
     /** Counts the minimum number of insert positions needed in a text to insert the [watermark] */

--- a/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
@@ -183,9 +183,9 @@ class TextWatermarker(
         file.content = result.toString()
 
         // Check if watermark fits at least one time into the text file with given positioning
-        if (insertPositions.count() < separatedWatermark.count()) {
+        if (insertPositions.count() < getMinimumInsertPositions(watermark)) {
             return OversizedWatermarkWarning(
-                separatedWatermark.count(),
+                getMinimumInsertPositions(watermark),
                 insertPositions.count(),
             ).into()
         }
@@ -228,7 +228,9 @@ class TextWatermarker(
                     sequence {
                         var lastSeparatorPosition = 0
                         for (separatorPosition in separatorPositions) {
-                            yield(lastSeparatorPosition to separatorPosition - 1)
+                            if (lastSeparatorPosition != separatorPosition - 1) {
+                                yield(lastSeparatorPosition to separatorPosition - 1)
+                            }
                             lastSeparatorPosition = separatorPosition + 1
                         }
                     }
@@ -326,7 +328,9 @@ class TextWatermarker(
     @JsName("getMinimumInsertPositionsBytes")
     fun getMinimumInsertPositions(watermark: List<Byte>): Int {
         val separatedWatermark = getSeparatedWatermark(watermark)
-        return separatedWatermark.count()
+        return if (separatorStrategy is SeparatorStrategy.StartEndSeparatorChars) {
+            separatedWatermark.count()
+        }else separatedWatermark.count()+1
     }
 
     /** Counts the minimum number of insert positions needed in a text to insert the [watermark] */

--- a/watermarker/src/commonTest/kotlin/unitTest/WatermarkerTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/WatermarkerTest.kt
@@ -94,7 +94,7 @@ class WatermarkerTest {
     fun textAddWatermark_watermarkTooLong_warningAndWatermarkedString() {
         // Arrange
         val watermark = "Hello, world!".encodeToByteArray().asList()
-        val expectedMessage = TextWatermarker.OversizedWatermarkWarning(53, 49).into().toString()
+        val expectedMessage = TextWatermarker.OversizedWatermarkWarning(54, 49).into().toString()
         val expected =
             "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod temp" +
                 "or invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero " +
@@ -169,18 +169,18 @@ class WatermarkerTest {
     }
 
     @Test
-    fun textGetWatermarks_exactlyOneWatermark_successAndWatermark() {
+    fun textGetWatermarks_exactlyOneWatermark_warningAndWatermark() {
         // Arrange
         val expected =
             listOf(
-                Watermark.fromString("a"),
+                Watermark(listOf(0, 97)),
             )
 
         // Act
         val result = watermarker.textGetWatermarks("a a a a a a a a a a")
 
         // Assert
-        assertTrue(result.isSuccess)
+        assertTrue(result.isWarning)
         assertEquals(expected, result.value)
     }
 

--- a/watermarker/src/jvmTest/kotlin/unitTest/fileWatermarker/TextWatermarkerTestJvm.kt
+++ b/watermarker/src/jvmTest/kotlin/unitTest/fileWatermarker/TextWatermarkerTestJvm.kt
@@ -62,7 +62,7 @@ class TextWatermarkerTestJvm {
         // Arrange
         val file = openTextFile("src/jvmTest/resources/lorem_ipsum.txt")
         val watermark = Watermark.fromString("This is a watermark that does not fit")
-        val expectedMessage = TextWatermarker.OversizedWatermarkWarning(149, 96).into().toString()
+        val expectedMessage = TextWatermarker.OversizedWatermarkWarning(150, 96).into().toString()
 
         // Act
         val result = textWatermarker.addWatermark(file, watermark)


### PR DESCRIPTION
## Description
- _**getMinimumInsertPositions**_ function now considers that for Strategies _**SingleSeparatorChar**_ and _**SkipInsertPosition**_ an additional byte is needed when exactly one watermark is inserted to differentiate between full and partial insertions
- _**addWatermark**_ function now warns users in the following case: Watermark fits but the ambiguity mentioned above occurs
- _**getWatermarks**_ function now correctly outputs a warning and single watermark for the _**SingleSeparatorChar**_ Strategy in the ambiguous case (success & empty watermark before, see linked issue)

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #159 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
