### PR TITLE
fix(watermarker): improve Watermark extraction performance

### DIFF
--- a/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/TextWatermarker.kt
@@ -265,14 +265,16 @@ class TextWatermarker(
 
         val status = Status()
         val watermarks = ArrayList<Watermark>()
+        val stringBuilder = StringBuilder(file.content)
+        var previousStart = 0
         for ((start, end) in sanitizedWatermarkRanges) {
             val content =
-                StringBuilder(file.content)
-                    .drop(start)
+                stringBuilder
+                    .deleteRange(0, start - previousStart)
                     .take(end - start + 1)
                     .filter { char -> char in transcoding.alphabet }
 
-            if (content.count() > 0) {
+            if (content.isNotEmpty()) {
                 val decoded =
                     with(transcoding.decode(content.asSequence())) {
                         if (!hasValue) {
@@ -284,6 +286,7 @@ class TextWatermarker(
 
                 watermarks.add(Watermark(decoded))
             }
+            previousStart = start
         }
 
         if (watermarkRanges.count() <= 0 && watermarks.isNotEmpty()) {


### PR DESCRIPTION
## Description
includes 2 changes to the TextWatermarker getWatermarks function

1. Stringbuilder added in #137 is now reused between Watermarks to avoid the additional init overhead each loop
2. During each loop the content size of the Stringbuilder is reduced using Stringbuilder native functions instead of just dropping increasingly long segments from the active substring.

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #168 

## Additional Information
Performance increases of up to 15x observed in extreme cases, example from the linked issue dropped from 6s to ~500ms

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
