### PR TITLE
feat(watermarker): add frequency analysis for watermarks

### DIFF
--- a/docs/docs/03-usage/10-watermarker/02-kotlin.md
+++ b/docs/docs/03-usage/10-watermarker/02-kotlin.md
@@ -54,7 +54,7 @@ custom return types (see [Concepts](../../../development/watermarker/concepts/#e
 for more details).*
 
 *Watermark extraction can be customized for different use cases using optional Boolean parameters
-(see [Watermarker](../index/#extraction-customization) for more details)*
+(see [Watermarker](../#extraction-customization) for more details)*
 
 ```kt title="src/main/kotlin/Main.kt" showLineNumbers
 import de.fraunhofer.isst.trend.watermarker.Watermarker

--- a/docs/docs/03-usage/10-watermarker/02-kotlin.md
+++ b/docs/docs/03-usage/10-watermarker/02-kotlin.md
@@ -21,11 +21,11 @@ information.
 See [Installation](../installation).
 
 ## Example: Watermarking Text with Text
-Below you can see an example project that inserts a text as watermark into a cover text and then
+Below you can see an example project that inserts a text as a watermark into a cover text and then
 extracts the watermark from the watermarked text.
 
 ### 1. Add Library as Dependency
-*Line 12 is the important line that adds our library as dependency into the project. Currently, we
+*Line 12 is the important line that adds our library as a dependency into the project. Currently, we
 are working with local deployment, so you will have to add `mavenLocal()` as repo (line 8) and
 publish the library to mavenLocal (see [Installation](../installation)).*
 ```kt title="build.gradle.kts" showLineNumbers
@@ -52,6 +52,10 @@ application {
 *The extension functions `handle()` and `unwrap()` are optional for easy error handling with our
 custom return types (see [Concepts](../../../development/watermarker/concepts/#error-handling-1)
 for more details).*
+
+*Watermark extraction can be customized for different use cases using optional Boolean parameters
+(see [Watermarker](../index/#extraction-customization) for more details)*
+
 ```kt title="src/main/kotlin/Main.kt" showLineNumbers
 import de.fraunhofer.isst.trend.watermarker.Watermarker
 import de.fraunhofer.isst.trend.watermarker.returnTypes.Result
@@ -63,19 +67,19 @@ fun main() {
     // *********************
     // ***** INSERTION *****
     // *********************
-    
-    // the coverText should be enhanced with a watermark
+
+    // the coverText to be enhanced with a watermark
     val coverText =
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor " +
             "incididunt ut labore et dolore magna aliqua. Blandit volutpat maecenas " +
             "volutpat blandit aliquam etiam erat velit."
-    // the watermarkText is that watermark that will be included in the coverText above
+    // the watermark text that will be included in the coverText above
     val watermarkText = "Test"
 
     // prepare watermarker
     val watermarker = Watermarker()
 
-    // creating a watermark with text as content
+    // creating a watermark with watermarkText as content
     val watermark = TextWatermark.new(watermarkText)
 
     // inserting the watermark into the cover text and handling potential errors and warnings
@@ -98,7 +102,35 @@ fun main() {
     // print the watermark text
     println("Found a watermark in the text:")
     println(extractedWatermark.text)
-    
+
+
+    // *******************************
+    // ***** Multiple watermarks *****
+    // *******************************
+
+    // for multiple watermarks in a single text an additional parameter 'singleWatermark = false'
+    // can be passed to the extraction function alongside the watermarked text, details are linked 
+    // above this code block 
+
+    // a second Watermark to illustrate multiple watermark extraction
+    val secondWatermarkText = "Okay"
+
+    // creating the second watermark
+    val secondWatermark = TextWatermark.new(secondWatermarkText)
+
+    // inserting the second watermark into the coverText
+    val secondWatermarkedText = watermarker.textAddWatermark(coverText, secondWatermark).unwrap()
+
+    // combining the watermarked texts to get two different watermarks in one Text
+    val combinedText = watermarkedText + secondWatermarkedText
+
+    // extract the watermarks from the watermarked text
+    val extractedMultipleWatermarks =
+        watermarker.textGetTextWatermarks(combinedText, singleWatermark = false).unwrap()
+
+    // print the watermarks found
+    for (extracted in extractedMultipleWatermarks) println("Found watermark: $extracted")
+
 }
 
 /**
@@ -111,7 +143,7 @@ fun main() {
  *  - nop
  */
 fun Status.handle() {
-    if (isSuccess) {
+    if (isSuccess && !this.hasCustomMessage) {
         return
     }
 
@@ -135,7 +167,7 @@ fun Status.handle() {
 fun <T> Result<T>.unwrap(): T {
     status.handle()
     checkNotNull(value) {
-        "A Result with a Status of type Success or Warning are expected to have a value"
+        "A Result with a Status of type Success or Warning is expected to have a value"
     }
 
     return value!!

--- a/docs/docs/03-usage/10-watermarker/03-java.md
+++ b/docs/docs/03-usage/10-watermarker/03-java.md
@@ -59,7 +59,7 @@ custom return types (see [Concepts](../../../development/watermarker/concepts/#e
 for more details).*
 
 *Watermark extraction can be customized for different use cases using optional Boolean parameters
-(see [Watermarker](../index/#extraction-customization) for more details)*
+(see [Watermarker](../#extraction-customization) for more details)*
 
 ```java title="src/main/java/Main.java" showLineNumbers
 import de.fraunhofer.isst.trend.watermarker.Watermarker;

--- a/docs/docs/03-usage/10-watermarker/index.mdx
+++ b/docs/docs/03-usage/10-watermarker/index.mdx
@@ -54,6 +54,20 @@ is designed to allow customizing its behavior in many ways:
 However, we do not provide preconfigured configuration options for these adjustments, you have to
 read the code and then create your own implementaitons.
 
+### Extraction Customizations
+The Extraction functions of the (Jvm-)Watermarker allow for passing additional parameters for
+specific use cases, **bold** indicates default values for (Jvm-)Watermarker in kotlin:
+- [`squash`](https://github.com/FraunhoferISST/TREND/blob/637c1622c5aa44668869017dae871f9b38e26abb/watermarker/src/commonMain/kotlin/Watermarker.kt#L228)
+= [**true**/false]: when true duplicate Watermarks are squashed together and only one copy is
+returned
+- [`singleWatermark`](https://github.com/FraunhoferISST/TREND/blob/81aca27b864baaef386eb800c75646cf33019299/watermarker/src/commonMain/kotlin/watermarks/Watermark.kt#L30)
+= [**true**/false]: when true only the most frequent Watermark is returned
+    - if multiple Watermarks appear with the same (highest) frequency a warning is returned with the Watermarks
+    - this is separate from the squashing above, duplicates of the most frequent Watermark(s) are still returned if squash = false
+- [`ErrorOnInvalidUTF8`](https://github.com/FraunhoferISST/TREND/blob/eb5f3b62bc31a63f985fa87c01522281adcb7c3e/watermarker/src/commonMain/kotlin/watermarks/TextWatermark.kt#L123)
+= [true/**false**]: For functions returning TextWatermarks only, when true throws a
+CharacterCodingException when encountering malformed UTF8 Bytes
+
 ## Kotlin Library: Special Characteristics
 Kotlin uses so-called
 [companion objects](https://kotlinlang.org/docs/object-declarations.html#companion-objects) to

--- a/watermarker/src/commonMain/kotlin/fileWatermarker/FileWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/FileWatermarker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ * Copyright (c) 2023-2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
  * that can be found in the LICENSE file.
@@ -47,21 +47,31 @@ interface FileWatermarker<File : WatermarkableFile> {
     /** Checks if [file] contains watermarks */
     fun containsWatermark(file: File): Boolean
 
-    /** Returns all watermarks in [file] */
-    fun getWatermarks(file: File): Result<List<Watermark>>
+    /**
+     * Returns all watermarks in [file]
+     * When [singleWatermark] is true: only the most frequent watermark is returned.
+     */
+    fun getWatermarks(
+        file: File,
+        singleWatermark: Boolean = false,
+    ): Result<List<Watermark>>
 
     /**
      * Returns all watermarks in [file] as Trendmarks.
      *
+     * When [singleWatermark] is true: only the most frequent watermark is returned.
      * Returns a warning if some watermarks could not be converted to Trendmarks.
      * Returns an error if no watermark could be converted to a Trendmark.
      */
-    fun getTrendmarks(file: File): Result<List<Trendmark>> =
-        getWatermarks(file).toTrendmarks("${getSource()}.getTrendmarks")
+    fun getTrendmarks(
+        file: File,
+        singleWatermark: Boolean = false,
+    ): Result<List<Trendmark>> = getWatermarks(file).toTrendmarks("${getSource()}.getTrendmarks")
 
     /**
      * Returns all watermarks in [file] as TextWatermarks.
      *
+     * When [singleWatermark] is true: only the most frequent watermark is returned.
      * When [errorOnInvalidUTF8] is true: invalid bytes sequences cause an error.
      *                           is false: invalid bytes sequences are replace with the char �.
      *
@@ -73,12 +83,23 @@ interface FileWatermarker<File : WatermarkableFile> {
      */
     fun getTextWatermarks(
         file: File,
+        singleWatermark: Boolean = false,
         errorOnInvalidUTF8: Boolean = false,
     ): Result<List<TextWatermark>> =
-        getWatermarks(file).toTextWatermarks(errorOnInvalidUTF8, "${getSource()}.getTextWatermarks")
+        getWatermarks(file, singleWatermark).toTextWatermarks(
+            errorOnInvalidUTF8,
+            "${getSource()}" +
+                ".getTextWatermarks",
+        )
 
-    /** Removes all watermarks in [file] and returns them */
-    fun removeWatermarks(file: File): Result<List<Watermark>>
+    /**
+     * Removes all watermarks in [file] and returns them
+     * When [singleWatermark] is true: only the most frequent watermark is returned.
+     */
+    fun removeWatermarks(
+        file: File,
+        singleWatermark: Boolean = false,
+    ): Result<List<Watermark>>
 
     /** Parses [bytes] as File */
     fun parseBytes(bytes: List<Byte>): Result<File>

--- a/watermarker/src/commonMain/kotlin/fileWatermarker/ZipWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/ZipWatermarker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ * Copyright (c) 2023-2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
  * that can be found in the LICENSE file.
@@ -40,22 +40,40 @@ object ZipWatermarker : FileWatermarker<ZipFile> {
         return false
     }
 
-    /** Returns all watermarks in [file] */
-    override fun getWatermarks(file: ZipFile): Result<List<Watermark>> {
+    /**
+     * Returns all watermarks in [file]
+     * When [singleWatermark] is true: only the most frequent watermark is returned.
+     */
+    override fun getWatermarks(
+        file: ZipFile,
+        singleWatermark: Boolean,
+    ): Result<List<Watermark>> {
         val watermarks = ArrayList<Watermark>()
         for (extraField in file.header.extraFields) {
             if (extraField.id == ZIP_WATERMARK_ID) {
                 watermarks.add(Watermark(extraField.data))
             }
         }
+        if (singleWatermark) {
+            return Watermark.mostFrequent(watermarks)
+        }
         return Result.success(watermarks)
     }
 
-    /** Removes all watermarks in [file] and returns them */
-    override fun removeWatermarks(file: ZipFile): Result<List<Watermark>> {
+    /**
+     * Removes all watermarks in [file] and returns them
+     * When [singleWatermark] is true: only the most frequent watermark is returned.
+     */
+    override fun removeWatermarks(
+        file: ZipFile,
+        singleWatermark: Boolean,
+    ): Result<List<Watermark>> {
         val watermarks = ArrayList<Watermark>()
         for (extraField in file.header.removeExtraFields(ZIP_WATERMARK_ID)) {
             watermarks.add(Watermark(extraField.data))
+        }
+        if (singleWatermark) {
+            return Watermark.mostFrequent(watermarks)
         }
         return Result.success(watermarks)
     }

--- a/watermarker/src/commonMain/kotlin/watermarks/Watermark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Watermark.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ * Copyright (c) 2023-2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
  * that can be found in the LICENSE file.
@@ -7,15 +7,59 @@
 package de.fraunhofer.isst.trend.watermarker.watermarks
 
 import de.fraunhofer.isst.trend.watermarker.helper.toHexString
+import de.fraunhofer.isst.trend.watermarker.returnTypes.Event
+import de.fraunhofer.isst.trend.watermarker.returnTypes.Result
 import kotlin.js.JsExport
 
 @JsExport
 open class Watermark(var watermarkContent: List<Byte>) {
     companion object {
+        const val SOURCE = "Watermark"
+
         /** Creates a Watermark from [text] */
         fun fromString(text: String): Watermark {
             val bytes = text.encodeToByteArray().asList()
             return Watermark(bytes)
+        }
+
+        /**
+         *  Returns only the most frequent [Watermark] from [watermarks].
+         *  Returns a Warning if more than one most frequent Watermark is found.
+         *  Returns an Error if an Exception is thrown.
+         *  */
+        fun mostFrequent(watermarks: List<Watermark>): Result<List<Watermark>> {
+            var result: Result<List<Watermark>> = Result.success(watermarks)
+            if (watermarks.isEmpty()) {
+                return result
+            }
+            val frequencyMap: Map<Watermark, Int>
+            val maxFrequency: Int
+            val mostFrequent = mutableListOf<Watermark>()
+            val filteredList = mutableListOf<Watermark>()
+
+            try {
+                frequencyMap = watermarks.groupingBy { it }.eachCount()
+                maxFrequency = frequencyMap.maxOf { it.value }
+                mostFrequent.addAll(frequencyMap.filter { it.value == maxFrequency }.keys)
+                for (watermark in mostFrequent) {
+                    for (i in 1..maxFrequency) {
+                        filteredList.add(watermark)
+                    }
+                }
+                result =
+                    if (mostFrequent.size > 1) {
+                        MultipleMostFrequentWarning(mostFrequent.size).into(filteredList)
+                    } else {
+                        Result.success(filteredList)
+                    }
+            } catch (e: Exception) {
+                result =
+                    FrequencyAnalysisError(
+                        e::class.simpleName ?: "Unknown Exception",
+                    ).into(emptyList())
+            } finally {
+                return result
+            }
         }
     }
 
@@ -40,4 +84,18 @@ open class Watermark(var watermarkContent: List<Byte>) {
 
     /** Exposes content.hashCode() */
     override fun hashCode(): Int = watermarkContent.hashCode()
+
+    class MultipleMostFrequentWarning(
+        private val WatermarkCount: Int,
+    ) : Event.Warning("$SOURCE.mostFrequent") {
+        /** Returns a String explaining the event */
+        override fun getMessage() = "$WatermarkCount most frequent watermarks found!"
+    }
+
+    class FrequencyAnalysisError(
+        private val type: String,
+    ) : Event.Error("$SOURCE.mostFrequent") {
+        /** Returns a String explaining the event */
+        override fun getMessage(): String = "Frequency analysis failed with exception: $type!"
+    }
 }

--- a/watermarker/src/commonTest/kotlin/unitTest/fileWatermarker/TextWatermarkerTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/fileWatermarker/TextWatermarkerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ * Copyright (c) 2023-2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
  * that can be found in the LICENSE file.
@@ -10,6 +10,8 @@ import de.fraunhofer.isst.trend.watermarker.fileWatermarker.DefaultTranscoding
 import de.fraunhofer.isst.trend.watermarker.fileWatermarker.SeparatorStrategy
 import de.fraunhofer.isst.trend.watermarker.fileWatermarker.TextWatermarker
 import de.fraunhofer.isst.trend.watermarker.fileWatermarker.TextWatermarkerBuilder
+import de.fraunhofer.isst.trend.watermarker.files.TextFile
+import de.fraunhofer.isst.trend.watermarker.watermarks.Watermark
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -58,6 +60,14 @@ class DefaultTranscodingTest {
 
 class TextWatermarkerTest {
     private val textWatermarker = TextWatermarker.default()
+    private val textFileDifferentWatermarks =
+        TextFile.fromString(
+            "Lorem ipsum dolor sit amet, consetetur sadipscing elitr," +
+                " sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat," +
+                " sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum" +
+                ".Lorem ipsum dolor sit amet, consetetur sadipscing elitr," +
+                " sed diam nonumy eirmod tempor invidunt ut labore et dolore magna",
+        )
 
     @Test
     fun placement_loremIpsum_success() {
@@ -167,6 +177,43 @@ class TextWatermarkerTest {
 
         // Assert
         assertEquals(expected, result)
+    }
+
+    @Test
+    fun getWatermarks_singleWatermark_Success() {
+        // Arrange
+        val expectedWatermark = Watermark.fromString("Okay")
+        val expected = listOf(expectedWatermark, expectedWatermark)
+
+        // Act
+        val result =
+            textWatermarker.getWatermarks(
+                textFileDifferentWatermarks,
+                singleWatermark = true,
+            )
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarks_multipleWatermark_Success() {
+        // Arrange
+        val firstWatermark = Watermark.fromString("Okay")
+        val secondWatermark = Watermark.fromString("Test")
+        val expected = listOf(firstWatermark, firstWatermark, secondWatermark)
+
+        // Act
+        val result =
+            textWatermarker.getWatermarks(
+                textFileDifferentWatermarks,
+                singleWatermark = false,
+            )
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.value)
     }
 
     @Test

--- a/watermarker/src/commonTest/kotlin/unitTest/watermarks/WatermarkTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/watermarks/WatermarkTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
+ * that can be found in the LICENSE file.
+ */
+package unitTest.watermarks
+
+import de.fraunhofer.isst.trend.watermarker.watermarks.RawTrendmark
+import de.fraunhofer.isst.trend.watermarker.watermarks.Watermark
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WatermarkTest {
+    @Test
+    fun mostFrequent_success() {
+        // Arrange
+        val firstWatermark = Watermark.fromString("test")
+        val secondWatermark = Watermark.fromString("okay")
+        val thirdWatermark = Watermark.fromString("yeah")
+        val watermarks =
+            listOf(
+                firstWatermark,
+                firstWatermark,
+                secondWatermark,
+                thirdWatermark,
+            )
+        val expectedResult = listOf(firstWatermark, firstWatermark)
+
+        // Act
+        val result = Watermark.mostFrequent(watermarks)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expectedResult, result.value)
+    }
+
+    @Test
+    fun mostFrequent_bytes_success() {
+        // Arrange
+        val firstWatermark = Watermark(listOf(0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8))
+        val secondWatermark = Watermark(listOf(0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18))
+        val thirdWatermark = Watermark(listOf(0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28))
+        val watermarks =
+            listOf(
+                firstWatermark,
+                firstWatermark,
+                secondWatermark,
+                thirdWatermark,
+            )
+        val expectedResult = listOf(firstWatermark, firstWatermark)
+
+        // Act
+        val result = Watermark.mostFrequent(watermarks)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expectedResult, result.value)
+    }
+
+    @Test
+    fun mostFrequent_empty_success() {
+        // Arrange
+        val watermarks = listOf<Watermark>()
+        val expectedResult = listOf<Watermark>()
+
+        // Act
+        val result = Watermark.mostFrequent(watermarks)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expectedResult, result.value)
+    }
+
+    @Test
+    fun mostFrequent_trendmark_success() {
+        // Arrange
+        val firstTrendmark = RawTrendmark.fromString("test")
+        val secondTrendmark = RawTrendmark.fromString("okay")
+        val thirdTrendmark = RawTrendmark.fromString("yeah")
+        val watermarks =
+            listOf(
+                firstTrendmark,
+                firstTrendmark,
+                secondTrendmark,
+                thirdTrendmark,
+            )
+        val expectedResult = listOf(firstTrendmark, firstTrendmark)
+
+        // Act
+        val result = Watermark.mostFrequent(watermarks)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expectedResult, result.value)
+    }
+
+    @Test
+    fun mostFrequent_warning() {
+        // Arrange
+        val firstWatermark = Watermark.fromString("test")
+        val secondWatermark = Watermark.fromString("okay")
+        val thirdWatermark = Watermark.fromString("yeah")
+        val watermarks =
+            listOf(
+                firstWatermark,
+                firstWatermark,
+                secondWatermark,
+                secondWatermark,
+                thirdWatermark,
+            )
+        val expectedResult =
+            listOf(
+                firstWatermark,
+                firstWatermark,
+                secondWatermark,
+                secondWatermark,
+            )
+
+        // Act
+        val result = Watermark.mostFrequent(watermarks)
+
+        // Assert
+        assertTrue(result.isWarning)
+        assertEquals(expectedResult, result.value)
+    }
+
+    @Test
+    fun multipleMostFrequentWarning_string_success() {
+        // Arrange
+        val warning = Watermark.MultipleMostFrequentWarning(9)
+        val expected = "Warning (Watermark.mostFrequent): 9 most frequent watermarks found!"
+
+        // Act
+        val result = warning.toString()
+
+        // Assert
+        assertEquals(result, expected)
+    }
+
+    @Test
+    fun frequencyAnalysisError_string_success() {
+        // Arrange
+        val error = Watermark.FrequencyAnalysisError("ErrorType")
+        val expected =
+            "Error (Watermark.mostFrequent): Frequency analysis failed with exception: ErrorType!"
+
+        // Act
+        val result = error.toString()
+
+        // Assert
+        assertEquals(result, expected)
+    }
+}

--- a/watermarker/src/jvmTest/kotlin/unitTest/JvmWatermarkerTest.kt
+++ b/watermarker/src/jvmTest/kotlin/unitTest/JvmWatermarkerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ * Copyright (c) 2023-2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
  * that can be found in the LICENSE file.
@@ -338,7 +338,13 @@ class JvmWatermarkerTest {
             }
 
         // Act
-        val result = watermarker.getWatermarks(source, null, false)
+        val result =
+            watermarker.getWatermarks(
+                source,
+                fileType = null,
+                squash = false,
+                singleWatermark = false,
+            )
 
         // Assert
         assertTrue(result.isSuccess)
@@ -355,7 +361,45 @@ class JvmWatermarkerTest {
             }
 
         // Act
-        val result = watermarker.getWatermarks(source)
+        val result =
+            watermarker.getWatermarks(
+                source,
+                singleWatermark = false,
+            )
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarks_differentWatermarks_successAndSingleWatermarkList() {
+        // Arrange
+        val source = "src/jvmTest/resources/lorem_ipsum_long_different_watermarks.txt"
+        val expected =
+            listOf("Okay", "Okay", "Okay", "Okay", "Okay").map {
+                Watermark.fromString(it)
+            }
+
+        // Act
+        val result = watermarker.getWatermarks(source, squash = false, singleWatermark = true)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarks_differentWatermarks_successAndSingleWatermark() {
+        // Arrange
+        val source = "src/jvmTest/resources/lorem_ipsum_long_different_watermarks.txt"
+        val expected =
+            listOf("Okay").map {
+                Watermark.fromString(it)
+            }
+
+        // Act
+        val result = watermarker.getWatermarks(source, squash = true, singleWatermark = true)
 
         // Assert
         assertTrue(result.isSuccess)
@@ -503,6 +547,24 @@ class JvmWatermarkerTest {
 
         // Cleanup
         File(target).delete()
+    }
+
+    @Test
+    fun removeWatermarks_differentWatermarks_successAndSingleWatermarkList() {
+        // Arrange
+        val source = "src/jvmTest/resources/lorem_ipsum_long_different_watermarks.txt"
+        val target = "src/jvmTest/resources/lorem_ipsum_long.txt"
+        val expected =
+            listOf("Okay", "Okay", "Okay", "Okay", "Okay").map {
+                Watermark.fromString(it)
+            }
+
+        // Act
+        val result = watermarker.removeWatermarks(source, target, singleWatermark = true)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.value)
     }
 
     @Test


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->
Adds a static frequency analysis function to the Watermark class and the option to only return the most frequent Watermark(s) from any Watermarker function that returns a list of Watermarks, as described by the additional context in the linked issue. Both Watermarker.kt and JvmWatermarker.kt use it by default.

Please note that frequency analysis is separate from squashing and can be used alone or in conjunction with it wherever supported.

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #190 
## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
