### PR TITLE
feat(watermarker): add Trendmark validation option for increased robustness

### DIFF
--- a/docs/docs/03-usage/10-watermarker/index.mdx
+++ b/docs/docs/03-usage/10-watermarker/index.mdx
@@ -64,9 +64,14 @@ returned
 = [**true**/false]: when true only the most frequent Watermark is returned
     - if multiple Watermarks appear with the same (highest) frequency a warning is returned with the Watermarks
     - this is separate from the squashing above, duplicates of the most frequent Watermark(s) are still returned if squash = false
-- [`ErrorOnInvalidUTF8`](https://github.com/FraunhoferISST/TREND/blob/eb5f3b62bc31a63f985fa87c01522281adcb7c3e/watermarker/src/commonMain/kotlin/watermarks/TextWatermark.kt#L123)
+- [`errorOnInvalidUTF8`](https://github.com/FraunhoferISST/TREND/blob/eb5f3b62bc31a63f985fa87c01522281adcb7c3e/watermarker/src/commonMain/kotlin/watermarks/TextWatermark.kt#L123)
 = [true/**false**]: For functions returning TextWatermarks only, when true throws a
 CharacterCodingException when encountering malformed UTF8 Bytes
+- [`validateAll`](https://github.com/FraunhoferISST/TREND/blob/8b47f1a373769656506a615436b558e362a8952c/watermarker/src/commonMain/kotlin/watermarks/Trendmark.kt#L56)
+= [**true**/false]: For functions returning Trendmarks only, when true calls the
+Trendmark validate() function, which will check for valid characteristics depending on the
+Trendmark type. See the [Trendmark](../../development/watermarker/trendmark) section for more
+details.
 
 ## Kotlin Library: Special Characteristics
 Kotlin uses so-called

--- a/watermarker/src/commonMain/kotlin/Watermarker.kt
+++ b/watermarker/src/commonMain/kotlin/Watermarker.kt
@@ -178,6 +178,7 @@ open class Watermarker {
      *
      * When [squash] is true: watermarks with the same content are merged.
      * When [singleWatermark] is true: only the most frequent watermark is returned.
+     * When [validateAll] is true: All resulting Trendmarks are validated to check for errors.
      *
      * Returns a warning if some watermarks could not be converted to Trendmarks.
      * Returns an error if no watermark could be converted to a Trendmark.
@@ -186,8 +187,19 @@ open class Watermarker {
         text: String,
         squash: Boolean = true,
         singleWatermark: Boolean = true,
-    ): Result<List<Trendmark>> =
-        textGetWatermarks(text, squash, singleWatermark).toTrendmarks("$SOURCE.textGetTrendmarks")
+        validateAll: Boolean = true,
+    ): Result<List<Trendmark>> {
+        val result =
+            textGetWatermarks(text, squash, singleWatermark)
+                .toTrendmarks("$SOURCE.textGetTrendmarks")
+        if (validateAll && result.hasValue && result.value!!.isNotEmpty()) {
+            for (trendmark in result.value) {
+                val validationStatus = trendmark.validate()
+                result.appendStatus(validationStatus)
+            }
+        }
+        return result
+    }
 
     /**
      * Returns all watermarks in [text] as TextWatermarks.


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->
Adds an optional parameter "validateAll" to Trendmark returning functions that triggers the Trendmark.validate() function on each Trendmark and appends the resulting Statuses before returning the Result.
This change is also reflected in the Documentation under Extraction Customizations.

(This PR also includes a minor typo fix and function documentation fix that I believe didn't warrant a separate issue/PR)

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #191 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
