### PR TITLE
fix(webinterface): single variable for kvisionVersion

### DIFF
--- a/webinterface/build.gradle.kts
+++ b/webinterface/build.gradle.kts
@@ -8,17 +8,14 @@
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
 // Versions
-val kvisionVersion = "8.2.0"
+val kvisionVersion: String by project
 
 val webDir = file("src/jsMain/web")
 
 plugins {
     val kotlinVersion = "2.1.10"
-    val kvisionVersion = "8.2.0"
-
     kotlin("plugin.serialization") version kotlinVersion
     kotlin("multiplatform") version kotlinVersion
-    id("io.kvision") version kvisionVersion
     id("org.jlleitschuh.gradle.ktlint") version "12.2.0"
     id("com.github.node-gradle.node") version "7.1.0"
 }

--- a/webinterface/build.gradle.kts
+++ b/webinterface/build.gradle.kts
@@ -8,14 +8,17 @@
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
 // Versions
-val kvisionVersion: String by project
+val kotlinVersion: String by System.getProperties()
+val kvisionVersion: String by System.getProperties()
 
 val webDir = file("src/jsMain/web")
 
 plugins {
-    val kotlinVersion = "2.1.10"
+    val kotlinVersion: String by System.getProperties()
+    val kvisionVersion: String by System.getProperties()
     kotlin("plugin.serialization") version kotlinVersion
     kotlin("multiplatform") version kotlinVersion
+    id("io.kvision") version kvisionVersion
     id("org.jlleitschuh.gradle.ktlint") version "12.2.0"
     id("com.github.node-gradle.node") version "7.1.0"
 }

--- a/webinterface/gradle.properties
+++ b/webinterface/gradle.properties
@@ -5,4 +5,5 @@
 # that can be found in the LICENSE file.
 #
 kotlin.js.compiler=ir
-kvisionVersion=8.2.0
+systemProp.kotlinVersion=2.1.10
+systemProp.kvisionVersion=8.2.0

--- a/webinterface/gradle.properties
+++ b/webinterface/gradle.properties
@@ -5,3 +5,4 @@
 # that can be found in the LICENSE file.
 #
 kotlin.js.compiler=ir
+kvisionVersion=8.2.0

--- a/webinterface/settings.gradle.kts
+++ b/webinterface/settings.gradle.kts
@@ -6,6 +6,12 @@
  */
 
 pluginManagement {
+    val kvisionVersion: String by settings
+
+    plugins {
+        id("io.kvision") version kvisionVersion
+    }
+
     repositories {
         gradlePluginPortal()
         mavenCentral()

--- a/webinterface/settings.gradle.kts
+++ b/webinterface/settings.gradle.kts
@@ -6,12 +6,6 @@
  */
 
 pluginManagement {
-    val kvisionVersion: String by settings
-
-    plugins {
-        id("io.kvision") version kvisionVersion
-    }
-
     repositories {
         gradlePluginPortal()
         mavenCentral()


### PR DESCRIPTION
## Description
- refactored build.gradle, settings.gradle and gradle.properties so that there is a "single source of truth" for the kvisionVersion
- this should make sure that the dependabot no longer misses additional variables when suggesting newer versions of kvision

## Linked Issue(s)
Fixes #29 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
