### PR TITLE
feat(watermarker): Extend squashing to all extraction and removal functions

### DIFF
--- a/watermarker/src/commonMain/kotlin/fileWatermarker/FileWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/fileWatermarker/FileWatermarker.kt
@@ -49,28 +49,37 @@ interface FileWatermarker<File : WatermarkableFile> {
 
     /**
      * Returns all watermarks in [file]
+     * When [squash] is true: watermarks with the same content are merged.
      * When [singleWatermark] is true: only the most frequent watermark is returned.
      */
     fun getWatermarks(
         file: File,
+        squash: Boolean = false,
         singleWatermark: Boolean = false,
     ): Result<List<Watermark>>
 
     /**
      * Returns all watermarks in [file] as Trendmarks.
      *
+     * When [squash] is true: watermarks with the same content are merged.
      * When [singleWatermark] is true: only the most frequent watermark is returned.
      * Returns a warning if some watermarks could not be converted to Trendmarks.
      * Returns an error if no watermark could be converted to a Trendmark.
      */
     fun getTrendmarks(
         file: File,
+        squash: Boolean = false,
         singleWatermark: Boolean = false,
-    ): Result<List<Trendmark>> = getWatermarks(file).toTrendmarks("${getSource()}.getTrendmarks")
+    ): Result<List<Trendmark>> =
+        getWatermarks(file, squash, singleWatermark).toTrendmarks(
+            "${getSource()}" +
+                ".getTrendmarks",
+        )
 
     /**
      * Returns all watermarks in [file] as TextWatermarks.
      *
+     * When [squash] is true: watermarks with the same content are merged.
      * When [singleWatermark] is true: only the most frequent watermark is returned.
      * When [errorOnInvalidUTF8] is true: invalid bytes sequences cause an error.
      *                           is false: invalid bytes sequences are replace with the char �.
@@ -83,10 +92,11 @@ interface FileWatermarker<File : WatermarkableFile> {
      */
     fun getTextWatermarks(
         file: File,
+        squash: Boolean = false,
         singleWatermark: Boolean = false,
         errorOnInvalidUTF8: Boolean = false,
     ): Result<List<TextWatermark>> =
-        getWatermarks(file, singleWatermark).toTextWatermarks(
+        getWatermarks(file, squash, singleWatermark).toTextWatermarks(
             errorOnInvalidUTF8,
             "${getSource()}" +
                 ".getTextWatermarks",
@@ -94,10 +104,12 @@ interface FileWatermarker<File : WatermarkableFile> {
 
     /**
      * Removes all watermarks in [file] and returns them
+     * When [squash] is true: watermarks with the same content are merged.
      * When [singleWatermark] is true: only the most frequent watermark is returned.
      */
     fun removeWatermarks(
         file: File,
+        squash: Boolean = false,
         singleWatermark: Boolean = false,
     ): Result<List<Watermark>>
 

--- a/watermarker/src/commonTest/kotlin/unitTest/fileWatermarker/TextWatermarkerTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/fileWatermarker/TextWatermarkerTest.kt
@@ -189,6 +189,26 @@ class TextWatermarkerTest {
         val result =
             textWatermarker.getWatermarks(
                 textFileDifferentWatermarks,
+                squash = false,
+                singleWatermark = true,
+            )
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarks_singleWatermark_SuccessAndSquash() {
+        // Arrange
+        val expectedWatermark = Watermark.fromString("Okay")
+        val expected = listOf(expectedWatermark)
+
+        // Act
+        val result =
+            textWatermarker.getWatermarks(
+                textFileDifferentWatermarks,
+                squash = true,
                 singleWatermark = true,
             )
 
@@ -208,6 +228,27 @@ class TextWatermarkerTest {
         val result =
             textWatermarker.getWatermarks(
                 textFileDifferentWatermarks,
+                squash = false,
+                singleWatermark = false,
+            )
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarks_multipleWatermark_SuccessAndSquash() {
+        // Arrange
+        val firstWatermark = Watermark.fromString("Okay")
+        val secondWatermark = Watermark.fromString("Test")
+        val expected = listOf(firstWatermark, secondWatermark)
+
+        // Act
+        val result =
+            textWatermarker.getWatermarks(
+                textFileDifferentWatermarks,
+                squash = true,
                 singleWatermark = false,
             )
 

--- a/watermarker/src/jvmMain/kotlin/JvmWatermarker.kt
+++ b/watermarker/src/jvmMain/kotlin/JvmWatermarker.kt
@@ -270,7 +270,7 @@ class JvmWatermarker : Watermarker() {
 
     /**
      * Removes all watermarks in [source] and returns them.
-     *
+     * When [squash] is true: watermarks with the same content are merged.
      * When [singleWatermark] is true: only the most frequent watermark is returned.
      * When [fileType] is null the type is taken from [source]'s extension.
      */
@@ -278,6 +278,7 @@ class JvmWatermarker : Watermarker() {
         source: String,
         target: String,
         fileType: String? = null,
+        squash: Boolean = true,
         singleWatermark: Boolean = true,
     ): Result<List<Watermark>> {
         val supportedFileType =
@@ -289,6 +290,7 @@ class JvmWatermarker : Watermarker() {
             supportedFileType.watermarker,
             source,
             target,
+            squash,
             singleWatermark,
         )
     }
@@ -297,7 +299,8 @@ class JvmWatermarker : Watermarker() {
         watermarker: FileWatermarker<T>,
         source: String,
         target: String,
-        singleWatermark: Boolean = true,
+        squash: Boolean,
+        singleWatermark: Boolean,
     ): Result<List<Watermark>> {
         val (status, bytes) =
             with(readFile(source)) {
@@ -311,7 +314,7 @@ class JvmWatermarker : Watermarker() {
             }
 
         val watermarks =
-            with(watermarker.removeWatermarks(file, singleWatermark)) {
+            with(watermarker.removeWatermarks(file, squash, singleWatermark)) {
                 status.appendStatus(this.status)
                 value
             }

--- a/watermarker/src/jvmTest/kotlin/unitTest/JvmWatermarkerTest.kt
+++ b/watermarker/src/jvmTest/kotlin/unitTest/JvmWatermarkerTest.kt
@@ -538,7 +538,30 @@ class JvmWatermarkerTest {
             )
 
         // Act
-        val result = watermarker.removeWatermarks(source, target)
+        val result = watermarker.removeWatermarks(source, target, squash = false)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expectedWatermarks, result.value)
+        assertTrue(areFilesEqual(expected, target))
+
+        // Cleanup
+        File(target).delete()
+    }
+
+    @Test
+    fun removeWatermarks_txtWatermark_successAndSquash() {
+        // Arrange
+        val source = "src/jvmTest/resources/lorem_ipsum_watermarked.txt"
+        val target = "src/jvmTest/resources/lorem_ipsum_test.txt"
+        val expected = "src/jvmTest/resources/lorem_ipsum.txt"
+        val expectedWatermarks =
+            listOf(
+                Watermark.fromString("Hello World"),
+            )
+
+        // Act
+        val result = watermarker.removeWatermarks(source, target, squash = true)
 
         // Assert
         assertTrue(result.isSuccess)
@@ -560,7 +583,13 @@ class JvmWatermarkerTest {
             }
 
         // Act
-        val result = watermarker.removeWatermarks(source, target, singleWatermark = true)
+        val result =
+            watermarker.removeWatermarks(
+                source,
+                target,
+                squash = false,
+                singleWatermark = true,
+            )
 
         // Assert
         assertTrue(result.isSuccess)


### PR DESCRIPTION
## Description
Adds the ability to squash resulting lists of Watermarks from all extraction and removal functions in JvmWatermarker (default true) and FileWatermarkers (default false), including TextWatermarker.

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #208 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
