### PR TITLE
feat(watermarker): refactor user facing Watermarkers

### DIFF
--- a/docs/docs/03-usage/10-watermarker/02-kotlin.md
+++ b/docs/docs/03-usage/10-watermarker/02-kotlin.md
@@ -57,11 +57,12 @@ for more details).*
 (see [Watermarker](../#extraction-customization) for more details)*
 
 ```kt title="src/main/kotlin/Main.kt" showLineNumbers
-import de.fraunhofer.isst.innamark.watermarker.Watermarker
+import de.fraunhofer.isst.innamark.watermarker.textWatermarkers.TextWatermarker
+import de.fraunhofer.isst.innamark.watermarker.textWatermarkers.PlainTextWatermarker
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Status
-import de.fraunhofer.isst.innamark.watermarker.watermarks.TextWatermark
 import kotlin.system.exitProcess
+import kotlin.text.decodeToString
 
 fun main() {
     // *********************
@@ -77,13 +78,10 @@ fun main() {
     val watermarkText = "Test"
 
     // prepare watermarker
-    val watermarker = Watermarker()
-
-    // creating a watermark with watermarkText as content
-    val watermark = TextWatermark.new(watermarkText)
+    val watermarker: TextWatermarker = PlainTextWatermarker()
 
     // inserting the watermark into the cover text and handling potential errors and warnings
-    val watermarkedText = watermarker.textAddWatermark(coverText, watermark).unwrap()
+    val watermarkedText = watermarker.addWatermark(coverText, watermarkText).unwrap()
 
     // print the watermarked text
     println("watermarked text:")
@@ -95,13 +93,14 @@ fun main() {
     // **********************
 
     // extract the watermark from the watermarked text
-    val extractedWatermarks = watermarker.textGetTextWatermarks(watermarkedText).unwrap()
+    val extractedWatermarks = watermarker.getWatermarks(watermarkedText).unwrap()
     check(extractedWatermarks.size == 1)
     val extractedWatermark = extractedWatermarks[0]
 
     // print the watermark text
     println("Found a watermark in the text:")
-    println(extractedWatermark.text)
+    println(extractedWatermark.watermarkContent.toByteArray().decodeToString())
+    println()
 
 
     // *******************************
@@ -115,21 +114,20 @@ fun main() {
     // a second Watermark to illustrate multiple watermark extraction
     val secondWatermarkText = "Okay"
 
-    // creating the second watermark
-    val secondWatermark = TextWatermark.new(secondWatermarkText)
-
     // inserting the second watermark into the coverText
-    val secondWatermarkedText = watermarker.textAddWatermark(coverText, secondWatermark).unwrap()
+    val secondWatermarkedText = watermarker.addWatermark(coverText, secondWatermarkText).unwrap()
 
     // combining the watermarked texts to get two different watermarks in one Text
     val combinedText = watermarkedText + secondWatermarkedText
 
     // extract the watermarks from the watermarked text
     val extractedMultipleWatermarks =
-        watermarker.textGetTextWatermarks(combinedText, singleWatermark = false).unwrap()
+        watermarker.getWatermarks(combinedText, singleWatermark = false).unwrap()
 
     // print the watermarks found
-    for (extracted in extractedMultipleWatermarks) println("Found watermark: $extracted")
+    for (extracted in extractedMultipleWatermarks) {
+        println("Found watermark: ${extracted.watermarkContent.toByteArray().decodeToString()}")
+    }
 
 }
 

--- a/docs/docs/03-usage/10-watermarker/02-kotlin.md
+++ b/docs/docs/03-usage/10-watermarker/02-kotlin.md
@@ -87,19 +87,17 @@ fun main() {
     println("watermarked text:")
     println(watermarkedText)
     println()
-    
+
     // **********************
     // ***** Extraction *****
     // **********************
 
     // extract the watermark from the watermarked text
-    val extractedWatermarks = watermarker.getWatermarks(watermarkedText).unwrap()
-    check(extractedWatermarks.size == 1)
-    val extractedWatermark = extractedWatermarks[0]
+    val extractedWatermark = watermarker.getWatermarkAsString(watermarkedText).unwrap()
 
     // print the watermark text
     println("Found a watermark in the text:")
-    println(extractedWatermark.watermarkContent.toByteArray().decodeToString())
+    println(extractedWatermark)
     println()
 
 
@@ -108,8 +106,8 @@ fun main() {
     // *******************************
 
     // for multiple watermarks in a single text an additional parameter 'singleWatermark = false'
-    // can be passed to the extraction function alongside the watermarked text, details are linked 
-    // above this code block 
+    // can be passed to the extraction function alongside the watermarked text, details are linked
+    // above this code block
 
     // a second Watermark to illustrate multiple watermark extraction
     val secondWatermarkText = "Okay"
@@ -126,7 +124,7 @@ fun main() {
 
     // print the watermarks found
     for (extracted in extractedMultipleWatermarks) {
-        println("Found watermark: ${extracted.watermarkContent.toByteArray().decodeToString()}")
+        println("Found watermark: ${extracted.watermarkContent.decodeToString()}")
     }
 
 }

--- a/docs/docs/03-usage/10-watermarker/03-java.md
+++ b/docs/docs/03-usage/10-watermarker/03-java.md
@@ -102,23 +102,11 @@ public class Main {
         // **********************
 
         // extract the watermark from the watermarked text
-        List<Watermark> extractedWatermarks =
-                unwrap(watermarker.getWatermarks(watermarkedText, false, false));
-
-
-        assert (extractedWatermarks.size() == 1);
-        Watermark extractedWatermark = extractedWatermarks.getFirst();
-
-        // get Watermark Bytes
-        byte[] extractedBytes = new byte[extractedWatermark.getWatermarkContent().size()];
-        for (int i = 0; i < extractedBytes.length; i++) {
-            extractedBytes[i] = extractedWatermark.getWatermarkContent().get(i);
-        }
+        String extractedWatermark = unwrap(watermarker.getWatermarkAsString(watermarkedText));
 
         // print the watermark text
         System.out.println("Found a watermark in the text:");
-        String extractedText = new String(extractedBytes, StandardCharsets.UTF_8);
-        System.out.println(extractedText);
+        System.out.println(extractedWatermark);
 
         // *******************************
         // ***** Multiple watermarks *****
@@ -141,19 +129,12 @@ public class Main {
         List<Watermark> extractedMultipleWatermarks =
                 unwrap(watermarker.getWatermarks(combinedText, false, false));
 
-        // get Watermark Bytes
-        List<byte[]> extractedMultipleBytes = new ArrayList<>();
-        for (Watermark watermark : extractedMultipleWatermarks) {
-            byte[] array = new byte[watermark.getWatermarkContent().size()];
-            for (int i = 0; i < array.length; i++) {
-                array[i] = watermark.getWatermarkContent().get(i);
-            }
-            extractedMultipleBytes.add(array);
-        }
 
         // convert Watermark Bytes to Strings
         List<String> extractedMultipleText = new ArrayList<>();
-        extractedMultipleBytes.forEach(array -> extractedMultipleText.add(new String(array, StandardCharsets.UTF_8)));
+        extractedMultipleWatermarks.forEach(
+                watermark -> extractedMultipleText.add(
+                        new String(watermark.getWatermarkContent(), StandardCharsets.UTF_8)));
 
         // print the watermarks found
         for (String content : extractedMultipleText) {

--- a/docs/docs/03-usage/10-watermarker/03-java.md
+++ b/docs/docs/03-usage/10-watermarker/03-java.md
@@ -62,11 +62,13 @@ for more details).*
 (see [Watermarker](../#extraction-customization) for more details)*
 
 ```java title="src/main/java/Main.java" showLineNumbers
-import de.fraunhofer.isst.innamark.watermarker.Watermarker;
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result;
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Status;
-import de.fraunhofer.isst.innamark.watermarker.watermarks.TextWatermark;
+import de.fraunhofer.isst.innamark.watermarker.textWatermarkers.PlainTextWatermarker;
+import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -85,13 +87,10 @@ public class Main {
         String watermarkText = "Test";
 
         // prepare watermarker
-        Watermarker watermarker = new Watermarker();
-
-        // creating a watermark with watermarkText as content
-        TextWatermark watermark = TextWatermark.Companion.create(watermarkText);
+        PlainTextWatermarker watermarker = new PlainTextWatermarker();
 
         // inserting the watermark into the cover text and handling potential errors and warnings
-        String watermarkedText = unwrap(watermarker.textAddWatermark(coverText, watermark));
+        String watermarkedText = unwrap(watermarker.addWatermark(coverText, watermarkText));
 
         // print the watermarked text
         System.out.println("watermarked text:");
@@ -103,41 +102,63 @@ public class Main {
         // **********************
 
         // extract the watermark from the watermarked text
-        List<TextWatermark> extractedWatermarks =
-                unwrap(watermarker.textGetTextWatermarks(watermarkedText, true, true, false));
+        List<Watermark> extractedWatermarks =
+                unwrap(watermarker.getWatermarks(watermarkedText, false, false));
+
+
         assert (extractedWatermarks.size() == 1);
-        TextWatermark extractedWatermark = extractedWatermarks.get(0);
+        Watermark extractedWatermark = extractedWatermarks.getFirst();
+
+        // get Watermark Bytes
+        byte[] extractedBytes = new byte[extractedWatermark.getWatermarkContent().size()];
+        for (int i = 0; i < extractedBytes.length; i++) {
+            extractedBytes[i] = extractedWatermark.getWatermarkContent().get(i);
+        }
 
         // print the watermark text
         System.out.println("Found a watermark in the text:");
-        System.out.println(extractedWatermark.getText());
+        String extractedText = new String(extractedBytes, StandardCharsets.UTF_8);
+        System.out.println(extractedText);
 
         // *******************************
         // ***** Multiple watermarks *****
         // *******************************
 
-        // for multiple watermarks in a single text the parameter 'singleWatermark' must be set 
-        // to 'false' when passed to the extraction function alongside the watermarked text, 
-        // details are linked above this code block 
+        // for multiple watermarks in a single text the parameter 'singleWatermark' must be set
+        // to 'false' when passed to the extraction function alongside the watermarked text,
+        // details are linked above this code block
 
         // a second Watermark to illustrate multiple watermark extraction
         String secondWatermarkText = "Okay";
 
-        // creating the second watermark
-        TextWatermark secondWatermark = TextWatermark.Companion.create(secondWatermarkText);
-
         // inserting the second watermark into the coverText
-        String secondWatermarkedText = unwrap(watermarker.textAddWatermark(coverText, secondWatermark));
+        String secondWatermarkedText = unwrap(watermarker.addWatermark(coverText, secondWatermarkText));
 
         // combining the watermarked texts to get two different watermarks in one Text
         String combinedText = watermarkedText + secondWatermarkedText;
 
         // extract the watermarks from the watermarked text
-        List<TextWatermark> extractedMultipleWatermarks =
-                unwrap(watermarker.textGetTextWatermarks(combinedText, true, false, false));
+        List<Watermark> extractedMultipleWatermarks =
+                unwrap(watermarker.getWatermarks(combinedText, false, false));
+
+        // get Watermark Bytes
+        List<byte[]> extractedMultipleBytes = new ArrayList<>();
+        for (Watermark watermark : extractedMultipleWatermarks) {
+            byte[] array = new byte[watermark.getWatermarkContent().size()];
+            for (int i = 0; i < array.length; i++) {
+                array[i] = watermark.getWatermarkContent().get(i);
+            }
+            extractedMultipleBytes.add(array);
+        }
+
+        // convert Watermark Bytes to Strings
+        List<String> extractedMultipleText = new ArrayList<>();
+        extractedMultipleBytes.forEach(array -> extractedMultipleText.add(new String(array, StandardCharsets.UTF_8)));
 
         // print the watermarks found
-        extractedMultipleWatermarks.forEach(System.out::println);
+        for (String content : extractedMultipleText) {
+            System.out.println("Watermark found: " + content);
+        }
 
     }
 

--- a/watermarker/src/commonMain/kotlin/binaryWatermarkers/BinaryWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/binaryWatermarkers/BinaryWatermarker.kt
@@ -8,6 +8,7 @@ package de.fraunhofer.isst.innamark.watermarker.binaryWatermarkers
 
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
 import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
+import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark.MultipleMostFrequentWarning
 
 /**
  * Interface for implementations facilitating watermarking of arbitrary non-text covers
@@ -33,6 +34,22 @@ interface BinaryWatermarker<CoverType> {
 
     /** Returns a [Boolean] indicating whether [cover] contains watermarks */
     fun containsWatermark(cover: CoverType): Boolean
+
+    /**
+     * Returns a [Result] containing the most frequent Watermark in [cover] as a String
+     *
+     * Result contains an empty String if no Watermarks were found.
+     * Result contains a [MultipleMostFrequentWarning] in cases where an unambiguous Watermark could not be extracted.
+     */
+    fun getWatermarkAsString(cover: CoverType): Result<String>
+
+    /**
+     * Returns a [Result] containing the most frequent Watermark in [cover] as a ByteArray
+     *
+     * Result contains an empty ByteArray if no Watermarks were found.
+     * Result contains a [MultipleMostFrequentWarning] in cases where an unambiguous Watermark could not be extracted.
+     */
+    fun getWatermarkAsByteArray(cover: CoverType): Result<ByteArray>
 
     /**
      * Returns a [Result] containing a list of [Watermark]s in [cover]

--- a/watermarker/src/commonMain/kotlin/binaryWatermarkers/BinaryWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/binaryWatermarkers/BinaryWatermarker.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
+ * that can be found in the LICENSE file.
+ */
 package de.fraunhofer.isst.innamark.watermarker.binaryWatermarkers
 
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result

--- a/watermarker/src/commonMain/kotlin/binaryWatermarkers/BinaryWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/binaryWatermarkers/BinaryWatermarker.kt
@@ -9,6 +9,7 @@ package de.fraunhofer.isst.innamark.watermarker.binaryWatermarkers
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
 import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
 import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark.MultipleMostFrequentWarning
+import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark.StringDecodeWarning
 
 /**
  * Interface for implementations facilitating watermarking of arbitrary non-text covers
@@ -40,6 +41,7 @@ interface BinaryWatermarker<CoverType> {
      *
      * Result contains an empty String if no Watermarks were found.
      * Result contains a [MultipleMostFrequentWarning] in cases where an unambiguous Watermark could not be extracted.
+     * Result contains a [StringDecodeWarning] in cases where a byte cannot be read as UTF-8.
      */
     fun getWatermarkAsString(cover: CoverType): Result<String>
 

--- a/watermarker/src/commonMain/kotlin/binaryWatermarkers/BinaryWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/binaryWatermarkers/BinaryWatermarker.kt
@@ -9,29 +9,43 @@ package de.fraunhofer.isst.innamark.watermarker.binaryWatermarkers
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
 import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
 
+/**
+ * Interface for implementations facilitating watermarking of arbitrary non-text covers
+ */
 interface BinaryWatermarker<CoverType> {
+    /** Adds a watermark created from [watermark] String to [cover] */
     fun addWatermark(
         cover: CoverType,
         watermark: String,
     ): Result<CoverType>
 
+    /** Adds a watermark created from [watermark] ByteArray to [cover] */
     fun addWatermark(
         cover: CoverType,
         watermark: ByteArray,
     ): Result<CoverType>
 
+    /** Adds watermark object [watermark] to [cover] */
     fun addWatermark(
         cover: CoverType,
         watermark: Watermark,
     ): Result<CoverType>
 
+    /** Returns a [Boolean] indicating whether [cover] contains watermarks */
     fun containsWatermark(cover: CoverType): Boolean
 
+    /**
+     * Returns a [Result] containing a list of [Watermark]s in [cover]
+     *
+     * When [squash] is true: watermarks with the same content are merged.
+     * When [singleWatermark] is true: only the most frequent watermark is returned.
+     */
     fun getWatermarks(
         cover: CoverType,
         squash: Boolean = false,
         singleWatermark: Boolean = false,
     ): Result<List<Watermark>>
 
+    /** Removes all watermarks from [cover] and returns a [Result] containing the cleaned cover */
     fun removeWatermark(cover: CoverType): Result<CoverType>
 }

--- a/watermarker/src/commonMain/kotlin/binaryWatermarkers/BinaryWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/binaryWatermarkers/BinaryWatermarker.kt
@@ -1,0 +1,31 @@
+package de.fraunhofer.isst.innamark.watermarker.binaryWatermarkers
+
+import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
+import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
+
+interface BinaryWatermarker<CoverType> {
+    fun addWatermark(
+        cover: CoverType,
+        watermark: String,
+    ): Result<CoverType>
+
+    fun addWatermark(
+        cover: CoverType,
+        watermark: ByteArray,
+    ): Result<CoverType>
+
+    fun addWatermark(
+        cover: CoverType,
+        watermark: Watermark,
+    ): Result<CoverType>
+
+    fun containsWatermark(cover: CoverType): Boolean
+
+    fun getWatermarks(
+        cover: CoverType,
+        squash: Boolean = false,
+        singleWatermark: Boolean = false,
+    ): Result<List<Watermark>>
+
+    fun removeWatermark(cover: CoverType): Result<CoverType>
+}

--- a/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
+++ b/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
+ * that can be found in the LICENSE file.
+ */
 package de.fraunhofer.isst.innamark.watermarker.binaryWatermarkers
 
 import de.fraunhofer.isst.innamark.watermarker.fileWatermarker.ZipWatermarker

--- a/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
+++ b/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
@@ -40,6 +40,7 @@ class ZipWatermarkerImpl : BinaryWatermarker<ZipFile> {
         val status = watermarker.addWatermark(cover, watermark.toList())
         return status.into(cover)
     }
+
     /**
      * Adds watermark object [watermark] to [cover]
      * Returns an error if the size of the ExtraFields exceed UShort::MAX

--- a/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
+++ b/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
@@ -11,9 +11,16 @@ import de.fraunhofer.isst.innamark.watermarker.files.ZipFile
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
 import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
 
+/**
+ * Implementation of [BinaryWatermarker] for [ZipFile] covers
+ */
 class ZipWatermarkerImpl : BinaryWatermarker<ZipFile> {
     private val watermarker = ZipWatermarker
 
+    /**
+     * Adds a watermark created from [watermark] String to [cover]
+     * Returns an error if the size of the ExtraFields exceed UShort::MAX
+     */
     override fun addWatermark(
         cover: ZipFile,
         watermark: String,
@@ -22,6 +29,10 @@ class ZipWatermarkerImpl : BinaryWatermarker<ZipFile> {
         return status.into(cover)
     }
 
+    /**
+     * Adds a watermark created from [watermark] ByteArray to [cover]
+     * Returns an error if the size of the ExtraFields exceed UShort::MAX
+     */
     override fun addWatermark(
         cover: ZipFile,
         watermark: ByteArray,
@@ -29,7 +40,10 @@ class ZipWatermarkerImpl : BinaryWatermarker<ZipFile> {
         val status = watermarker.addWatermark(cover, watermark.toList())
         return status.into(cover)
     }
-
+    /**
+     * Adds watermark object [watermark] to [cover]
+     * Returns an error if the size of the ExtraFields exceed UShort::MAX
+     */
     override fun addWatermark(
         cover: ZipFile,
         watermark: Watermark,

--- a/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
+++ b/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
@@ -9,6 +9,7 @@ package de.fraunhofer.isst.innamark.watermarker.binaryWatermarkers
 import de.fraunhofer.isst.innamark.watermarker.fileWatermarker.ZipWatermarker
 import de.fraunhofer.isst.innamark.watermarker.files.ZipFile
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
+import de.fraunhofer.isst.innamark.watermarker.returnTypes.Status
 import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
 
 /**
@@ -60,7 +61,14 @@ class ZipWatermarkerImpl : BinaryWatermarker<ZipFile> {
     override fun getWatermarkAsString(cover: ZipFile): Result<String> {
         val watermarks = getWatermarks(cover, false, true)
         if (watermarks.value?.isNotEmpty() ?: return Result.success("")) {
-            return watermarks.status.into(watermarks.value[0].watermarkContent.decodeToString())
+            val decoded =
+                watermarks.status.into(
+                    watermarks.value[0].watermarkContent.decodeToString(),
+                )
+            if (decoded.value!!.contains('\uFFFD')) {
+                decoded.appendStatus(Status(Watermark.StringDecodeWarning("ZipWatermarkerImpl")))
+            }
+            return decoded
         } else {
             return Result.success("")
         }

--- a/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
+++ b/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
@@ -37,7 +37,7 @@ class ZipWatermarkerImpl : BinaryWatermarker<ZipFile> {
         cover: ZipFile,
         watermark: ByteArray,
     ): Result<ZipFile> {
-        val status = watermarker.addWatermark(cover, watermark.toList())
+        val status = watermarker.addWatermark(cover, watermark)
         return status.into(cover)
     }
 
@@ -55,6 +55,24 @@ class ZipWatermarkerImpl : BinaryWatermarker<ZipFile> {
 
     override fun containsWatermark(cover: ZipFile): Boolean {
         return watermarker.containsWatermark(cover)
+    }
+
+    override fun getWatermarkAsString(cover: ZipFile): Result<String> {
+        val watermarks = getWatermarks(cover, false, true)
+        if (watermarks.value?.isNotEmpty() ?: return Result.success("")){
+            return watermarks.status.into(watermarks.value[0].watermarkContent.decodeToString())
+        } else {
+            return Result.success("")
+        }
+    }
+
+    override fun getWatermarkAsByteArray(cover: ZipFile): Result<ByteArray> {
+        val watermarks = getWatermarks(cover, false, true)
+        if (watermarks.value?.isNotEmpty() ?: return Result.success(ByteArray(0))) {
+            return watermarks.status.into(watermarks.value[0].watermarkContent)
+        } else {
+            return Result.success(ByteArray(0))
+        }
     }
 
     override fun getWatermarks(

--- a/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
+++ b/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
@@ -59,7 +59,7 @@ class ZipWatermarkerImpl : BinaryWatermarker<ZipFile> {
 
     override fun getWatermarkAsString(cover: ZipFile): Result<String> {
         val watermarks = getWatermarks(cover, false, true)
-        if (watermarks.value?.isNotEmpty() ?: return Result.success("")){
+        if (watermarks.value?.isNotEmpty() ?: return Result.success("")) {
             return watermarks.status.into(watermarks.value[0].watermarkContent.decodeToString())
         } else {
             return Result.success("")

--- a/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
+++ b/watermarker/src/commonMain/kotlin/binaryWatermarkers/ZipWatermarkerImpl.kt
@@ -1,0 +1,51 @@
+package de.fraunhofer.isst.innamark.watermarker.binaryWatermarkers
+
+import de.fraunhofer.isst.innamark.watermarker.fileWatermarker.ZipWatermarker
+import de.fraunhofer.isst.innamark.watermarker.files.ZipFile
+import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
+import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
+
+class ZipWatermarkerImpl : BinaryWatermarker<ZipFile> {
+    private val watermarker = ZipWatermarker
+
+    override fun addWatermark(
+        cover: ZipFile,
+        watermark: String,
+    ): Result<ZipFile> {
+        val status = watermarker.addWatermark(cover, Watermark.fromString(watermark))
+        return status.into(cover)
+    }
+
+    override fun addWatermark(
+        cover: ZipFile,
+        watermark: ByteArray,
+    ): Result<ZipFile> {
+        val status = watermarker.addWatermark(cover, watermark.toList())
+        return status.into(cover)
+    }
+
+    override fun addWatermark(
+        cover: ZipFile,
+        watermark: Watermark,
+    ): Result<ZipFile> {
+        val status = watermarker.addWatermark(cover, watermark)
+        return status.into(cover)
+    }
+
+    override fun containsWatermark(cover: ZipFile): Boolean {
+        return watermarker.containsWatermark(cover)
+    }
+
+    override fun getWatermarks(
+        cover: ZipFile,
+        squash: Boolean,
+        singleWatermark: Boolean,
+    ): Result<List<Watermark>> {
+        return watermarker.getWatermarks(cover, squash, singleWatermark)
+    }
+
+    override fun removeWatermark(cover: ZipFile): Result<ZipFile> {
+        val status = watermarker.removeWatermarks(cover).status
+        return status.into(cover)
+    }
+}

--- a/watermarker/src/commonMain/kotlin/textWatermarkers/PlainTextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/textWatermarkers/PlainTextWatermarker.kt
@@ -51,6 +51,7 @@ class PlainTextWatermarker(
         val status = watermarker.addWatermark(textFile, watermark.toList())
         return status.into(textFile.content)
     }
+
     /**
      * Adds a watermark created from [watermark] ByteArray to [cover]
      *
@@ -63,6 +64,7 @@ class PlainTextWatermarker(
     ): Result<String> {
         return addWatermark(cover, watermark.encodeToByteArray())
     }
+
     /**
      * Adds watermark object [watermark] to [cover]
      *

--- a/watermarker/src/commonMain/kotlin/textWatermarkers/PlainTextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/textWatermarkers/PlainTextWatermarker.kt
@@ -48,7 +48,7 @@ class PlainTextWatermarker(
         watermark: ByteArray,
     ): Result<String> {
         val textFile = TextFile.fromString(cover)
-        val status = watermarker.addWatermark(textFile, watermark.toList())
+        val status = watermarker.addWatermark(textFile, watermark)
         return status.into(textFile.content)
     }
 
@@ -82,6 +82,24 @@ class PlainTextWatermarker(
 
     override fun containsWatermark(cover: String): Boolean {
         return watermarker.containsWatermark(TextFile.fromString(cover))
+    }
+
+    override fun getWatermarkAsString(cover: String): Result<String> {
+        val watermarks = getWatermarks(cover, false, true)
+        if (watermarks.value?.isNotEmpty() ?: return Result.success("")) {
+            return watermarks.status.into(watermarks.value[0].watermarkContent.decodeToString())
+        } else {
+            return Result.success("")
+        }
+    }
+
+    override fun getWatermarkAsByteArray(cover: String): Result<ByteArray> {
+        val watermarks = getWatermarks(cover, false, true)
+        if (watermarks.value?.isNotEmpty() ?: return Result.success(ByteArray(0))) {
+            return watermarks.status.into(watermarks.value[0].watermarkContent)
+        } else {
+            return Result.success(ByteArray(0))
+        }
     }
 
     override fun getWatermarks(

--- a/watermarker/src/commonMain/kotlin/textWatermarkers/PlainTextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/textWatermarkers/PlainTextWatermarker.kt
@@ -14,6 +14,14 @@ import de.fraunhofer.isst.innamark.watermarker.files.TextFile
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
 import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
 
+/**
+ * Implementation of [de.fraunhofer.isst.innamark.watermarker.textWatermarkers.TextWatermarker] for watermarking plaintext
+ *
+ * Takes optional arguments to customize behavior:
+ * - [transcoding]: for defining the watermarking alphabet, encoding, and decoding.
+ * - [separatorStrategy]: for defining how multiple watermarks are separated.
+ * - [placement]: function for finding positions where transcoding alphabet characters are inserted.
+ */
 class PlainTextWatermarker(
     private val transcoding: Transcoding = DefaultTranscoding,
     private val separatorStrategy: SeparatorStrategy =
@@ -29,7 +37,12 @@ class PlainTextWatermarker(
     // create instance of (old) TextWatermarker with provided parameters (or defaults)
     private val watermarker = TextWatermarker(transcoding, separatorStrategy, placement)
 
-    // override functions
+    /**
+     * Adds a watermark created from [watermark] String to [cover]
+     *
+     * Returns a warning if the watermark does not fit at least a single time into the file.
+     * Returns an error if the text file contains a character from the transcoding alphabet.
+     */
     override fun addWatermark(
         cover: String,
         watermark: ByteArray,
@@ -38,14 +51,24 @@ class PlainTextWatermarker(
         val status = watermarker.addWatermark(textFile, watermark.toList())
         return status.into(textFile.content)
     }
-
+    /**
+     * Adds a watermark created from [watermark] ByteArray to [cover]
+     *
+     * Returns a warning if the watermark does not fit at least a single time into the file.
+     * Returns an error if the text file contains a character from the transcoding alphabet.
+     */
     override fun addWatermark(
         cover: String,
         watermark: String,
     ): Result<String> {
         return addWatermark(cover, watermark.encodeToByteArray())
     }
-
+    /**
+     * Adds watermark object [watermark] to [cover]
+     *
+     * Returns a warning if the watermark does not fit at least a single time into the file.
+     * Returns an error if the text file contains a character from the transcoding alphabet.
+     */
     override fun addWatermark(
         cover: String,
         watermark: Watermark,

--- a/watermarker/src/commonMain/kotlin/textWatermarkers/PlainTextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/textWatermarkers/PlainTextWatermarker.kt
@@ -12,6 +12,7 @@ import de.fraunhofer.isst.innamark.watermarker.fileWatermarker.TextWatermarker
 import de.fraunhofer.isst.innamark.watermarker.fileWatermarker.Transcoding
 import de.fraunhofer.isst.innamark.watermarker.files.TextFile
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
+import de.fraunhofer.isst.innamark.watermarker.returnTypes.Status
 import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
 
 /**
@@ -87,7 +88,15 @@ class PlainTextWatermarker(
     override fun getWatermarkAsString(cover: String): Result<String> {
         val watermarks = getWatermarks(cover, false, true)
         if (watermarks.value?.isNotEmpty() ?: return Result.success("")) {
-            return watermarks.status.into(watermarks.value[0].watermarkContent.decodeToString())
+            val decoded =
+                watermarks.status.into(
+                    watermarks.value[0].watermarkContent
+                        .decodeToString(),
+                )
+            if (decoded.value!!.contains('\uFFFD')) {
+                decoded.appendStatus(Status(Watermark.StringDecodeWarning("PlainTextWatermarker")))
+            }
+            return decoded
         } else {
             return Result.success("")
         }

--- a/watermarker/src/commonMain/kotlin/textWatermarkers/PlainTextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/textWatermarkers/PlainTextWatermarker.kt
@@ -1,0 +1,69 @@
+package de.fraunhofer.isst.innamark.watermarker.textWatermarkers
+
+import de.fraunhofer.isst.innamark.watermarker.fileWatermarker.DefaultTranscoding
+import de.fraunhofer.isst.innamark.watermarker.fileWatermarker.SeparatorStrategy
+import de.fraunhofer.isst.innamark.watermarker.fileWatermarker.TextWatermarker
+import de.fraunhofer.isst.innamark.watermarker.fileWatermarker.Transcoding
+import de.fraunhofer.isst.innamark.watermarker.files.TextFile
+import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
+import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
+
+class PlainTextWatermarker(
+    private val transcoding: Transcoding = DefaultTranscoding,
+    private val separatorStrategy: SeparatorStrategy =
+        SeparatorStrategy.SingleSeparatorChar(DefaultTranscoding.SEPARATOR_CHAR),
+    private val placement: (String) -> List<Int> = { string ->
+        sequence {
+            for ((index, char) in string.withIndex()) {
+                if (char == ' ') yield(index)
+            }
+        }.toMutableList() // mutable for JS compatibility on empty lists
+    },
+) : de.fraunhofer.isst.innamark.watermarker.textWatermarkers.TextWatermarker {
+    // create instance of (old) TextWatermarker with provided parameters (or defaults)
+    private val watermarker = TextWatermarker(transcoding, separatorStrategy, placement)
+
+    // override functions
+    override fun addWatermark(
+        cover: String,
+        watermark: ByteArray,
+    ): Result<String> {
+        val textFile = TextFile.fromString(cover)
+        val status = watermarker.addWatermark(textFile, watermark.toList())
+        return status.into(textFile.content)
+    }
+
+    override fun addWatermark(
+        cover: String,
+        watermark: String,
+    ): Result<String> {
+        return addWatermark(cover, watermark.encodeToByteArray())
+    }
+
+    override fun addWatermark(
+        cover: String,
+        watermark: Watermark,
+    ): Result<String> {
+        val textFile = TextFile.fromString(cover)
+        val status = watermarker.addWatermark(textFile, watermark)
+        return status.into(textFile.content)
+    }
+
+    override fun containsWatermark(cover: String): Boolean {
+        return watermarker.containsWatermark(TextFile.fromString(cover))
+    }
+
+    override fun getWatermarks(
+        cover: String,
+        squash: Boolean,
+        singleWatermark: Boolean,
+    ): Result<List<Watermark>> {
+        return watermarker.getWatermarks(TextFile.fromString(cover), squash, singleWatermark)
+    }
+
+    override fun removeWatermarks(cover: String): Result<String> {
+        val textFile = TextFile.fromString(cover)
+        val result = watermarker.removeWatermarks(textFile)
+        return result.status.into(textFile.content)
+    }
+}

--- a/watermarker/src/commonMain/kotlin/textWatermarkers/PlainTextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/textWatermarkers/PlainTextWatermarker.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
+ * that can be found in the LICENSE file.
+ */
 package de.fraunhofer.isst.innamark.watermarker.textWatermarkers
 
 import de.fraunhofer.isst.innamark.watermarker.fileWatermarker.DefaultTranscoding

--- a/watermarker/src/commonMain/kotlin/textWatermarkers/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/textWatermarkers/TextWatermarker.kt
@@ -9,6 +9,7 @@ package de.fraunhofer.isst.innamark.watermarker.textWatermarkers
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
 import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
 import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark.MultipleMostFrequentWarning
+import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark.StringDecodeWarning
 
 /**
  * Interface for implementations facilitating watermarking of [String] covers
@@ -40,6 +41,7 @@ interface TextWatermarker {
      *
      * Result contains an empty String if no Watermarks were found.
      * Result contains a [MultipleMostFrequentWarning] in cases where an unambiguous Watermark could not be extracted.
+     * Result contains a [StringDecodeWarning] in cases where a byte cannot be read as UTF-8.
      */
     fun getWatermarkAsString(cover: String): Result<String>
 

--- a/watermarker/src/commonMain/kotlin/textWatermarkers/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/textWatermarkers/TextWatermarker.kt
@@ -1,0 +1,59 @@
+package de.fraunhofer.isst.innamark.watermarker.textWatermarkers
+
+import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
+import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
+
+/**
+ * Concept: Client application specific Transcoding, Strategy, and Placement are passed to the
+ * concrete implementation at creation and not modified after
+ *
+ * Ideas like zerowidth etc. would be handled by separate, as yet unimplemented concrete
+ * Watermarkers since it requires differences in the actual add functions, not just Transcoding,
+ * Strategy, and Placement
+ *
+ * The basic idea of inserting Unicode Chars between words of a given String remains unchanged
+ * throughout implementations of this Interface
+ */
+
+interface TextWatermarker {
+    /**
+     * Watermarks [cover] String with a Watermark containing [watermark] String
+     */
+    fun addWatermark(
+        cover: String,
+        watermark: String,
+    ): Result<String>
+
+    /**
+     * Watermarks [cover] String with a Watermark containing [watermark] Bytes
+     */
+    fun addWatermark(
+        cover: String,
+        watermark: ByteArray,
+    ): Result<String>
+
+    fun addWatermark(
+        cover: String,
+        watermark: Watermark,
+    ): Result<String>
+
+    /**
+     * Checks the provided [cover] String for Watermark characters
+     */
+    fun containsWatermark(cover: String): Boolean
+
+    /**
+     * Extracts and returns Watermarks
+     */
+    fun getWatermarks(
+        cover: String,
+        squash: Boolean = false,
+        singleWatermark: Boolean = false,
+    ): Result<List<Watermark>>
+
+    /**
+     * Returns the provided [cover] String with any Watermark characters replaced with regular
+     * spaces.
+     */
+    fun removeWatermarks(cover: String): Result<String>
+}

--- a/watermarker/src/commonMain/kotlin/textWatermarkers/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/textWatermarkers/TextWatermarker.kt
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
+ * that can be found in the LICENSE file.
+ */
 package de.fraunhofer.isst.innamark.watermarker.textWatermarkers
 
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result

--- a/watermarker/src/commonMain/kotlin/textWatermarkers/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/textWatermarkers/TextWatermarker.kt
@@ -8,6 +8,7 @@ package de.fraunhofer.isst.innamark.watermarker.textWatermarkers
 
 import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
 import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
+import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark.MultipleMostFrequentWarning
 
 /**
  * Interface for implementations facilitating watermarking of [String] covers
@@ -33,6 +34,22 @@ interface TextWatermarker {
 
     /** Returns a [Boolean] indicating whether [cover] contains watermarks */
     fun containsWatermark(cover: String): Boolean
+
+    /**
+     * Returns a [Result] containing the most frequent Watermark in [cover] as a String
+     *
+     * Result contains an empty String if no Watermarks were found.
+     * Result contains a [MultipleMostFrequentWarning] in cases where an unambiguous Watermark could not be extracted.
+     */
+    fun getWatermarkAsString(cover: String): Result<String>
+
+    /**
+     * Returns a [Result] containing the most frequent Watermark in [cover] as a ByteArray
+     *
+     * Result contains an empty ByteArray if no Watermarks were found.
+     * Result contains a [MultipleMostFrequentWarning] in cases where an unambiguous Watermark could not be extracted.
+     */
+    fun getWatermarkAsByteArray(cover: String): Result<ByteArray>
 
     /**
      * Returns a [Result] containing a list of [Watermark]s in [cover]

--- a/watermarker/src/commonMain/kotlin/textWatermarkers/TextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/textWatermarkers/TextWatermarker.kt
@@ -10,46 +10,35 @@ import de.fraunhofer.isst.innamark.watermarker.returnTypes.Result
 import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
 
 /**
- * Concept: Client application specific Transcoding, Strategy, and Placement are passed to the
- * concrete implementation at creation and not modified after
- *
- * Ideas like zerowidth etc. would be handled by separate, as yet unimplemented concrete
- * Watermarkers since it requires differences in the actual add functions, not just Transcoding,
- * Strategy, and Placement
- *
- * The basic idea of inserting Unicode Chars between words of a given String remains unchanged
- * throughout implementations of this Interface
+ * Interface for implementations facilitating watermarking of [String] covers
  */
-
 interface TextWatermarker {
-    /**
-     * Watermarks [cover] String with a Watermark containing [watermark] String
-     */
+    /** Adds a watermark created from [watermark] String to [cover] */
     fun addWatermark(
         cover: String,
         watermark: String,
     ): Result<String>
 
-    /**
-     * Watermarks [cover] String with a Watermark containing [watermark] Bytes
-     */
+    /** Adds a watermark created from [watermark] ByteArray to [cover] */
     fun addWatermark(
         cover: String,
         watermark: ByteArray,
     ): Result<String>
 
+    /** Adds watermark object [watermark] to [cover] */
     fun addWatermark(
         cover: String,
         watermark: Watermark,
     ): Result<String>
 
-    /**
-     * Checks the provided [cover] String for Watermark characters
-     */
+    /** Returns a [Boolean] indicating whether [cover] contains watermarks */
     fun containsWatermark(cover: String): Boolean
 
     /**
-     * Extracts and returns Watermarks
+     * Returns a [Result] containing a list of [Watermark]s in [cover]
+     *
+     * When [squash] is true: watermarks with the same content are merged.
+     * When [singleWatermark] is true: only the most frequent watermark is returned.
      */
     fun getWatermarks(
         cover: String,
@@ -57,9 +46,6 @@ interface TextWatermarker {
         singleWatermark: Boolean = false,
     ): Result<List<Watermark>>
 
-    /**
-     * Returns the provided [cover] String with any Watermark characters replaced with regular
-     * spaces.
-     */
+    /** Removes all watermarks from [cover] and returns a [Result] containing the cleaned cover */
     fun removeWatermarks(cover: String): Result<String>
 }

--- a/watermarker/src/commonMain/kotlin/watermarks/Watermark.kt
+++ b/watermarker/src/commonMain/kotlin/watermarks/Watermark.kt
@@ -88,6 +88,15 @@ open class Watermark(var watermarkContent: ByteArray) {
     /** Exposes content.hashCode() */
     override fun hashCode(): Int = watermarkContent.contentHashCode()
 
+    class StringDecodeWarning(
+        private val SOURCE: String,
+    ) : Event.Warning("$SOURCE.getWatermarkAsString") {
+        /** Returns a String explaining the event */
+        override fun getMessage() =
+            "Malformed UTF-8 bytes were found in the Watermark and were " +
+                "replaced by \uFFFD"
+    }
+
     class MultipleMostFrequentWarning(
         private val WatermarkCount: Int,
     ) : Event.Warning("$SOURCE.mostFrequent") {

--- a/watermarker/src/commonTest/kotlin/unitTest/textWatermarkers/PlainTextWatermarkerTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/textWatermarkers/PlainTextWatermarkerTest.kt
@@ -51,6 +51,7 @@ class PlainTextWatermarkerTest {
     val watermarkBytes = watermark.encodeToByteArray()
     val watermark2 = "Okay"
     val watermarkBytes2 = watermark2.encodeToByteArray()
+    val malformedBytes = byteArrayOf(0x54.toByte(), 0x65.toByte(), 0x73.toByte(), 0xFF.toByte())
 
     @Test
     fun getWatermarkAsString_unmarkedText_Success() {
@@ -103,6 +104,22 @@ class PlainTextWatermarkerTest {
 
         // Assert
         assertTrue(result.isSuccess)
+        assertEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarkAsString_singleWatermark_StringDecodeWarning() {
+        // Arrange
+        val expected = "Tes" + '\uFFFD'
+        val expectedStatus = Watermark.StringDecodeWarning("PlainTextWatermarker")
+        val watermarked = watermarker.addWatermark(loremIpsum, malformedBytes)
+
+        // Act
+        val result = watermarker.getWatermarkAsString(watermarked.value!!)
+
+        // Assert
+        assertTrue(result.isWarning)
+        assertEquals(expectedStatus.getMessage(), result.getMessage())
         assertEquals(expected, result.value)
     }
 

--- a/watermarker/src/commonTest/kotlin/unitTest/textWatermarkers/PlainTextWatermarkerTest.kt
+++ b/watermarker/src/commonTest/kotlin/unitTest/textWatermarkers/PlainTextWatermarkerTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This work is licensed under the Fraunhofer License (on the basis of the MIT license)
+ * that can be found in the LICENSE file.
+ */
+package unitTest.textWatermarkers
+
+import de.fraunhofer.isst.innamark.watermarker.textWatermarkers.PlainTextWatermarker
+import de.fraunhofer.isst.innamark.watermarker.watermarks.Watermark
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PlainTextWatermarkerTest {
+    val watermarker = PlainTextWatermarker()
+    val loremIpsum =
+        "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonu" +
+            "my eirmod tempor invidunt ut labore et dolore magna aliquyam erat," +
+            " sed diam voluptua. At vero eos et accusam et justo duo dolores et" +
+            " ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est " +
+            "Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur" +
+            " sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labor" +
+            "e et dolore magna aliquyam erat, sed diam voluptua. At vero eos et" +
+            " accusam et justo duo dolores et ea rebum. Stet clita kasd gubergr" +
+            "en, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+    val watermarkedText =
+        "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonu" +
+            "my eirmod tempor invidunt ut labore et dolore magna aliquyam erat," +
+            " sed diam voluptua. At vero eos et accusam et justo duo dolores et" +
+            " ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est " +
+            "Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur" +
+            " sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labor" +
+            "e et dolore magna aliquyam erat, sed diam voluptua. At vero eos et" +
+            " accusam et justo duo dolores et ea rebum. Stet clita kasd gubergr" +
+            "en, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+    val watermarkedText2 =
+        "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonu" +
+            "my eirmod tempor invidunt ut labore et dolore magna aliquyam erat," +
+            " sed diam voluptua. At vero eos et accusam et justo duo dolores et" +
+            " ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est " +
+            "Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur" +
+            " sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labor" +
+            "e et dolore magna aliquyam erat, sed diam voluptua. At vero eos et" +
+            " accusam et justo duo dolores et ea rebum. Stet clita kasd gubergr" +
+            "en, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+    val combinedTextEqual = watermarkedText + watermarkedText2
+    val combinedTextUnequal = watermarkedText + watermarkedText2 + watermarkedText2
+    val watermark = "Test"
+    val watermarkBytes = watermark.encodeToByteArray()
+    val watermark2 = "Okay"
+    val watermarkBytes2 = watermark2.encodeToByteArray()
+
+    @Test
+    fun getWatermarkAsString_unmarkedText_Success() {
+        // Arrange
+        val expected = ""
+
+        // Act
+        val result = watermarker.getWatermarkAsString(loremIpsum)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarkAsString_singleWatermark_Success() {
+        // Arrange
+        val expected = watermark
+
+        // Act
+        val result = watermarker.getWatermarkAsString(watermarkedText)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarkAsString_multipleWatermarks_equalAndWarning() {
+        // Arrange
+        val expected = watermark
+        val expectedStatus = Watermark.MultipleMostFrequentWarning(2)
+
+        // Act
+        val result = watermarker.getWatermarkAsString(combinedTextEqual)
+
+        // Assert
+        assertTrue(result.isWarning)
+        assertEquals(result.status.getMessage(), expectedStatus.getMessage())
+        assertEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarkAsString_multipleWatermarks_unequalAndSuccess() {
+        // Arrange
+        val expected = watermark2
+
+        // Act
+        val result = watermarker.getWatermarkAsString(combinedTextUnequal)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarkAsByteArray_unmarkedText_Success() {
+        // Arrange
+        val expected = byteArrayOf()
+
+        // Act
+        val result = watermarker.getWatermarkAsByteArray(loremIpsum)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertContentEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarkAsByteArray_singleWatermark_Success() {
+        // Arrange
+        val expected = watermarkBytes
+
+        // Act
+        val result = watermarker.getWatermarkAsByteArray(watermarkedText)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertContentEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarkAsByteArray_multipleWatermarks_equalAndWarning() {
+        // Arrange
+        val expected = watermarkBytes
+        val expectedStatus = Watermark.MultipleMostFrequentWarning(2)
+
+        // Act
+        val result = watermarker.getWatermarkAsByteArray(combinedTextEqual)
+
+        // Assert
+        assertTrue(result.isWarning)
+        assertEquals(result.status.getMessage(), expectedStatus.getMessage())
+        assertContentEquals(expected, result.value)
+    }
+
+    @Test
+    fun getWatermarkAsByteArray_multipleWatermarks_unequalAndSuccess() {
+        // Arrange
+        val expected = watermarkBytes2
+
+        // Act
+        val result = watermarker.getWatermarkAsByteArray(combinedTextUnequal)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        assertContentEquals(expected, result.value)
+    }
+}


### PR DESCRIPTION
## Description
Adds new interfaces and implementations to be used by library users instead of previous Watermarkers. Currently the newly added Implementations still use old Watermarker classes internally, these internals need to be cleaned up in a separate step.

User-facing classes work on Strings and ByteArrays, while updating the Docs I noticed classes like Watermark still use List<Byte> which causes some awkward conversions, especially in Java, an additional refactor of those Watermark classes should be considered in my opinion.

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #226

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/TREND/blob/main/CLA.md) and I hereby accept and sign the CLA.
