### PR TITLE
chore(cli): update cli after watermarker refactor

### DIFF
--- a/cli/src/main/kotlin/Main.kt
+++ b/cli/src/main/kotlin/Main.kt
@@ -37,8 +37,8 @@ fun main(args: Array<String>) {
 }
 
 /**
- * Parses the CLI arguments and calls the corresponding functions
- * Prints usage information if the CLI arguments cannot be parsed
+ * Parses the CLI arguments and calls the corresponding functions.
+ * Prints usage information if the CLI arguments cannot be parsed.
  */
 @OptIn(ExperimentalCli::class)
 fun cli(args: Array<String>) {
@@ -142,8 +142,8 @@ fun cli(args: Array<String>) {
 }
 
 /**
- * Adds a watermark containing [message] to file [source]
- * Changes are written to [target] or [source] if target is null
+ * Adds a watermark containing [message] to file at [source] by wrapping it in a [RawInnamarkTag].
+ * Changes are written to [target] or [source] if target is null.
  */
 fun add(
     message: String,
@@ -171,9 +171,9 @@ fun add(
 }
 
 /**
- * Prints a list of all watermarks in [source]
+ * Prints a list of all watermarks in the file at [source].
  *
- * Uses watermark squashing when [verbose] is false
+ * Uses watermark squashing when [verbose] is false.
  */
 fun list(
     source: String,
@@ -212,10 +212,10 @@ fun list(
 }
 
 /**
- * Removes all watermarks from [source] and prints them
- * Changes are written to [target] or [source] if target is null
+ * Removes all watermarks from [source].
+ * Changes are written to [target] or [source] if target is null.
  *
- * Handles the Results of parsing, removing and writing
+ * Handles the Results of parsing, removing and writing.
  */
 fun remove(
     source: String,
@@ -240,7 +240,7 @@ fun remove(
     println("Removed all watermarks from ${getTargetHint(source, target)}:")
 }
 
-/** Adds a watermark containing [message] to [text] and prints the resulting string */
+/** Adds a watermark containing [message] to [text] and prints the resulting string. */
 fun textAdd(
     text: String,
     message: String,
@@ -252,9 +252,9 @@ fun textAdd(
 }
 
 /**
- * Prints a list of all watermarks in [text]
+ * Prints a list of all watermarks in [text].
  *
- * Uses watermark squashing when [verbose] is false
+ * Uses watermark squashing when [verbose] is false.
  */
 fun textList(
     text: String,
@@ -266,7 +266,7 @@ fun textList(
     printWatermarks(watermarks)
 }
 
-/** Removes all watermarks from [text] and prints the resulting string */
+/** Removes all watermarks from [text] and prints the resulting string. */
 fun textRemove(text: String) {
     if (watermarker.containsWatermark(text)) {
         val cleaned = watermarker.removeWatermarks(text).unwrap()
@@ -293,7 +293,7 @@ fun getTargetHint(
         source
     }
 
-/** Prints each watermark in [watermarks] with a separator between each one */
+/** Prints each watermark in [watermarks] with a separator between each one. */
 fun printWatermarks(watermarks: List<Watermark>) {
     val indexStringLen = min(watermarks.size.toString().length, 70)
 
@@ -306,7 +306,7 @@ fun printWatermarks(watermarks: List<Watermark>) {
     if (watermarks.isNotEmpty()) println("-".repeat(80))
 }
 
-/** Prints each event to STDOUT or STDERR using the toString Method if type is not SUCCESS */
+/** Prints each event to STDOUT or STDERR using the toString Method if type is not SUCCESS. */
 fun Status.print() {
     if (this.getEvents().isEmpty()) {
         when {

--- a/cli/src/main/kotlin/Main.kt
+++ b/cli/src/main/kotlin/Main.kt
@@ -157,17 +157,23 @@ fun add(
     val status = Status.success()
 
     if (sourceType.equals("text", ignoreCase = true)) {
-        status.appendStatus(textFileWatermarker.addWatermark(
-            source,
-            realTarget,
-            watermark,
-            fileType = "txt"))
+        status.appendStatus(
+            textFileWatermarker.addWatermark(
+                source,
+                realTarget,
+                watermark,
+                fileType = "txt",
+            ),
+        )
     } else if (sourceType.equals("zip", ignoreCase = true)) {
-        status.appendStatus(zipFileWatermarker.addWatermark(
-            source,
-            realTarget,
-            watermark,
-            fileType = "zip"))
+        status.appendStatus(
+            zipFileWatermarker.addWatermark(
+                source,
+                realTarget,
+                watermark,
+                fileType = "zip",
+            ),
+        )
     } else {
         status.appendStatus(SupportedFileType.NoFileTypeError(source).into())
     }

--- a/cli/src/main/kotlin/Main.kt
+++ b/cli/src/main/kotlin/Main.kt
@@ -157,9 +157,17 @@ fun add(
     val status = Status.success()
 
     if (sourceType.equals("text", ignoreCase = true)) {
-        status.appendStatus(textFileWatermarker.addWatermark(source, realTarget, watermark))
+        status.appendStatus(textFileWatermarker.addWatermark(
+            source,
+            realTarget,
+            watermark,
+            fileType = "txt"))
     } else if (sourceType.equals("zip", ignoreCase = true)) {
-        status.appendStatus(zipFileWatermarker.addWatermark(source, realTarget, watermark))
+        status.appendStatus(zipFileWatermarker.addWatermark(
+            source,
+            realTarget,
+            watermark,
+            fileType = "zip"))
     } else {
         status.appendStatus(SupportedFileType.NoFileTypeError(source).into())
     }
@@ -186,14 +194,14 @@ fun list(
         if (sourceType.equals("text", ignoreCase = true)) {
             textFileWatermarker.getWatermarks(
                 source,
-                fileType,
+                fileType = "txt",
                 squash = !verbose,
                 singleWatermark = false,
             )
         } else if (sourceType.equals("zip", ignoreCase = true)) {
             zipFileWatermarker.getWatermarks(
                 source,
-                fileType,
+                fileType = "zip",
                 squash = !verbose,
                 singleWatermark = false,
             )
@@ -227,9 +235,9 @@ fun remove(
 
     val status =
         if (sourceType.equals("text", ignoreCase = true)) {
-            textFileWatermarker.removeWatermarks(source, realTarget)
+            textFileWatermarker.removeWatermarks(source, realTarget, fileType = "txt")
         } else if (sourceType.equals("zip", ignoreCase = true)) {
-            zipFileWatermarker.removeWatermarks(source, realTarget)
+            zipFileWatermarker.removeWatermarks(source, realTarget, fileType = "zip")
         } else {
             SupportedFileType.NoFileTypeError(source).into()
         }

--- a/watermarker/src/commonMain/kotlin/watermarkers/text/PlainTextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/watermarkers/text/PlainTextWatermarker.kt
@@ -180,7 +180,7 @@ class PlainTextWatermarker(
         }
 
     /**
-     * Adds a watermark created from [watermark] String to [cover]
+     * Adds a watermark created from [watermark] ByteArray to [cover]
      *
      * Returns a [OversizedWatermarkWarning] if the watermark does not fit at least a single time into the cover.
      * Returns a [ContainsAlphabetCharsError] if the cover contains a character from the transcoding alphabet.
@@ -240,7 +240,7 @@ class PlainTextWatermarker(
     }
 
     /**
-     * Adds a watermark created from [watermark] ByteArray to [cover]
+     * Adds a watermark created from [watermark] String to [cover]
      *
      * Returns a [OversizedWatermarkWarning] if the watermark does not fit at least a single time into the cover.
      * Returns a [ContainsAlphabetCharsError] if the cover contains a character from the transcoding alphabet.

--- a/watermarker/src/commonMain/kotlin/watermarkers/text/PlainTextWatermarker.kt
+++ b/watermarker/src/commonMain/kotlin/watermarkers/text/PlainTextWatermarker.kt
@@ -574,12 +574,12 @@ class PlainTextWatermarker(
     ) : Event.Success() {
         /** Returns a String explaining the event */
         override fun getMessage(): String =
-            "Added complete Watermark ${if (incomplete) {
-                startPositions.size - 1
+            if (incomplete) {
+                "Added complete Watermark ${startPositions.size - 1} times and incomplete " +
+                    "Watermark once. Positions: $startPositions."
             } else {
-                startPositions.size
+                "Added Watermark ${startPositions.size} times. Positions: $startPositions."
             }
-            } times. Starting positions: $startPositions."
     }
 
     class AlphabetContainsSeparatorError(val chars: List<Char>) : Event.Error(SOURCE) {

--- a/watermarker/src/commonTest/kotlin/watermarkers/text/unitTest/PlainTextWatermarkerTest.kt
+++ b/watermarker/src/commonTest/kotlin/watermarkers/text/unitTest/PlainTextWatermarkerTest.kt
@@ -736,10 +736,23 @@ class PlainTextWatermarkerTest {
     }
 
     @Test
-    fun success_string_success() {
+    fun success_stringComplete_success() {
         // Arrange
-        val error = PlainTextWatermarker.Success(listOf(1, 2, 3))
-        val expected = "Success: Added Watermark 3 times. Positions: [1, 2, 3]."
+        val error = PlainTextWatermarker.Success(listOf(1, 2, 3), incomplete = false)
+        val expected = "Success: Added complete Watermark 3 times. Starting positions: [1, 2, 3]."
+
+        // Act
+        val result = error.toString()
+
+        // Assert
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun success_stringIncomplete_success() {
+        // Arrange
+        val error = PlainTextWatermarker.Success(listOf(1, 2, 3), incomplete = true)
+        val expected = "Success: Added complete Watermark 2 times. Starting positions: [1, 2, 3]."
 
         // Act
         val result = error.toString()

--- a/watermarker/src/commonTest/kotlin/watermarkers/text/unitTest/PlainTextWatermarkerTest.kt
+++ b/watermarker/src/commonTest/kotlin/watermarkers/text/unitTest/PlainTextWatermarkerTest.kt
@@ -739,7 +739,7 @@ class PlainTextWatermarkerTest {
     fun success_stringComplete_success() {
         // Arrange
         val error = PlainTextWatermarker.Success(listOf(1, 2, 3), incomplete = false)
-        val expected = "Success: Added complete Watermark 3 times. Starting positions: [1, 2, 3]."
+        val expected = "Success: Added Watermark 3 times. Positions: [1, 2, 3]."
 
         // Act
         val result = error.toString()
@@ -752,7 +752,9 @@ class PlainTextWatermarkerTest {
     fun success_stringIncomplete_success() {
         // Arrange
         val error = PlainTextWatermarker.Success(listOf(1, 2, 3), incomplete = true)
-        val expected = "Success: Added complete Watermark 2 times. Starting positions: [1, 2, 3]."
+        val expected =
+            "Success: Added complete Watermark 2 times and incomplete Watermark once. " +
+                "Positions: [1, 2, 3]."
 
         // Act
         val result = error.toString()

--- a/watermarker/src/jvmTest/kotlin/watermarkers/file/unitTest/TextFileWatermarkerTestJvm.kt
+++ b/watermarker/src/jvmTest/kotlin/watermarkers/file/unitTest/TextFileWatermarkerTestJvm.kt
@@ -45,7 +45,8 @@ class TextFileWatermarkerTestJvm {
         val filePath = "src/jvmTest/resources/lorem_ipsum.txt"
         val watermark = Watermark.fromString("Hello World")
         val expected = openTextFile("src/jvmTest/resources/lorem_ipsum_watermarked.txt")
-        val expectedMessage = PlainTextWatermarker.Success(listOf(5, 273, 538)).into().toString()
+        val expectedMessage =
+            PlainTextWatermarker.Success(listOf(5, 273, 538), true).into().toString()
 
         // Act
         val result = textWatermarker.addWatermark(filePath, tempFile.toString(), watermark)
@@ -62,7 +63,7 @@ class TextFileWatermarkerTestJvm {
         val filePath = "src/jvmTest/resources/lorem_ipsum.txt"
         val watermark = "Hello World"
         val expected = openTextFile("src/jvmTest/resources/lorem_ipsum_innamarked.txt")
-        val expectedMessage = PlainTextWatermarker.Success(listOf(5, 295)).into().toString()
+        val expectedMessage = PlainTextWatermarker.Success(listOf(5, 295), true).into().toString()
 
         // Act
         val result = textWatermarker.addWatermark(filePath, tempFile.toString(), watermark)


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->
updates the cli tool after the big watermarker refactor in #303 to use the new watermarker classes and insert RawInnamarkTags by default. As there are no automated tests for the cli I tested each command manually and recommend the reviewer do the same.
After following the [installation instructions](https://fraunhoferisst.github.io/Innamark/docs/usage/cli/installation/) the available commands are structured as follows (since the current documentation doesn't provide details yet):

```
- Innamark [-t <file type>] add <watermark> <source path> [<target path>]
- Innamark [-v -t <file type>] list <source path>
- Innamark [-t <file type>] remove <source path> [<target path>]
- Innamark text add <cover string> <watermark string>
- Innamark [-v] text list <watermarked text string>
- Innamark text remove <watermarked text string>
```

square brackets denote optional arguments, file type can be "text" or "zip" (case insensitive)

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #259 

## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/Innamark/blob/main/CLA.md) and I hereby accept and sign the CLA.
