### PR TITLE
fix(watermarker): update gradle configuration

### DIFF
--- a/.github/workflows/test_watermarker.yml
+++ b/.github/workflows/test_watermarker.yml
@@ -65,4 +65,4 @@ jobs:
       - name: Run tests
         id: test
         working-directory: watermarker
-        run: ./gradlew test
+        run: ./gradlew allTests

--- a/watermarker/build.gradle.kts
+++ b/watermarker/build.gradle.kts
@@ -43,7 +43,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("org.kotlincrypto.hash:sha3:0.8.0")
+                implementation("org.kotlincrypto.hash:sha3:0.7.1")
             }
         }
         val commonTest by getting {

--- a/watermarker/build.gradle.kts
+++ b/watermarker/build.gradle.kts
@@ -30,7 +30,6 @@ kotlin {
 
     jvmToolchain(21)
     jvm {
-        withJava()
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
         }

--- a/watermarker/gradle.properties
+++ b/watermarker/gradle.properties
@@ -5,4 +5,3 @@
 # that can be found in the LICENSE file.
 #
 kotlin.code.style=official
-kotlin.js.compiler=ir

--- a/watermarker/kotlin-js-store/yarn.lock
+++ b/watermarker/kotlin-js-store/yarn.lock
@@ -2513,11 +2513,6 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@5.5.4:
-  version "5.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
-  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
-
 ua-parser-js@^0.7.30:
   version "0.7.35"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.35.tgz#8bda4827be4f0b1dda91699a29499575a1f1d307"


### PR DESCRIPTION
## Description
<!-- Describe and give details about the changes. -->
removes some deprecated gradle options that are no longer supported (withJava() sets now included by default, IR compiler now default) and changes org.kotlincrypto.hash.sha3 to 0.7.1 after 0.8.0 (updated in #286) caused build errors related to KotlinJs.

## Linked Issue(s)
<!-- Please add the Issue number(s) that will be solved or are related to this PR. -->
Fixes #330 
## CLA
By submitting this pull request, I have read the [Corporate Contributor License Agreement (CLA)](https://github.com/FraunhoferISST/Innamark/blob/main/CLA.md) and I hereby accept and sign the CLA.
